### PR TITLE
Add start menu and resource preloading

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,9 +1,13 @@
 let config, level;
 let canvas = document.getElementById('gameCanvas');
 let ctx = canvas.getContext('2d');
+let startButton = document.getElementById('startButton');
+startButton.style.display = 'none';
 
 // Sprites
 let playerImg = new Image(), coinImg = new Image();
+playerImg.onload = checkStart;
+coinImg.onload = checkStart;
 playerImg.src = 'assets/player.png';
 coinImg.src = 'assets/coin.png';
 
@@ -15,10 +19,18 @@ fetch('config.json').then(r=>r.json()).then(c=>{ config = c; checkStart(); });
 fetch('level1.json').then(r=>r.json()).then(l=>{ level = l; checkStart(); });
 
 let ready = 0;
-function checkStart() { ready++; if (ready===2) startGame(); }
+function checkStart() {
+  ready++;
+  if (ready === 4) {
+    startButton.style.display = 'block';
+  }
+}
 
 let player = { x:0, y:0, size:32 }, coin = { x:0, y:0, size:32 }, score=0;
+startButton.addEventListener('click', startGame);
 function startGame() {
+  document.getElementById('startMenu').style.display = 'none';
+  canvas.style.display = 'block';
   player.x = level.playerStart.x;
   player.y = level.playerStart.y;
   coin.x = level.coinStart.x;

--- a/index.html
+++ b/index.html
@@ -6,11 +6,16 @@
   <style>
     body { background: #111; display: flex; flex-direction: column; align-items: center; color: #fff;}
     canvas { background: #222; border: 2px solid #fff; margin-top: 24px; }
+    #startMenu { margin-top: 20px; }
+    #startButton { font-size: 18px; padding: 10px 20px; }
   </style>
 </head>
 <body>
   <h1>Attrape la pièce !</h1>
-  <canvas id="gameCanvas" width="400" height="400"></canvas>
+  <div id="startMenu">
+    <button id="startButton">Démarrer</button>
+  </div>
+  <canvas id="gameCanvas" width="400" height="400" style="display:none;"></canvas>
   <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- preload sprites and data before starting
- add a simple start menu overlay in HTML
- hide canvas until the player presses the new start button

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68860fea10e0832b8cbcbaad87c9b453