### PR TITLE
Add block-breaking and visual improvements

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -69,6 +69,7 @@ export class GameEngine {
             if (e.code === 'ArrowLeft') this.keys.left = false;
             if (e.code === 'ArrowRight') this.keys.right = false;
             if (e.code === 'Space' || e.code === 'ArrowUp') this.keys.jump = false;
+            if (e.code === 'KeyA') this.keys.action = false;
         });
         
         this.canvas.addEventListener('mousemove', e => {

--- a/player.js
+++ b/player.js
@@ -307,7 +307,7 @@ return null;
                 const angle = Math.sin(progress * Math.PI) * 1.5;
                 ctx.rotate(angle);
             }
-            ctx.drawImage(toolAsset, -12, -12, 24, 24);
+            ctx.drawImage(toolAsset, -6, -6, 12, 12);
         }
         ctx.restore();
     }
@@ -320,6 +320,11 @@ return null;
 
         ctx.translate(this.x + this.w / 2, this.y + this.h / 2);
         if (this.dir === 1) ctx.scale(-1, 1);
+        if (this.swingTimer > 0) {
+            const progress = (15 - this.swingTimer) / 15;
+            const angle = Math.sin(progress * Math.PI) * 0.2;
+            ctx.rotate(angle);
+        }
 
         const skinAsset = assets[skinKey];
         if (skinAsset) {


### PR DESCRIPTION
## Summary
- fix action key so it resets on keyup
- shrink tool sprites and rotate player when swinging
- add sun, clouds and grass decorations

## Testing
- `node --check game.js`
- `node --check engine.js`
- `node --check player.js`


------
https://chatgpt.com/codex/tasks/task_e_688b448c1788832b8858b9ad655f0afa