### PR TITLE
Ajout option Echap et outils

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -51,7 +51,7 @@ export class GameEngine {
     // Configure les écouteurs d'événements pour le clavier et la souris
     setupInput() {
         document.addEventListener('keydown', e => {
-            if (this.gameLogic.isPaused && this.gameLogic.isPaused() && e.code !== 'KeyC' && e.code !== 'KeyO') return;
+            if (this.gameLogic.isPaused && this.gameLogic.isPaused() && e.code !== 'KeyC' && e.code !== 'KeyO' && e.code !== 'Escape') return;
 
             if (e.code === 'ArrowLeft') this.keys.left = true;
             if (e.code === 'ArrowRight') this.keys.right = true;
@@ -59,6 +59,7 @@ export class GameEngine {
             if (e.code === 'KeyA') this.keys.action = true;
             if (e.code === 'KeyC' && this.gameLogic.toggleMenu) this.gameLogic.toggleMenu('controls');
             if (e.code === 'KeyO' && this.gameLogic.toggleMenu) this.gameLogic.toggleMenu('options');
+            if (e.code === 'Escape' && this.gameLogic.toggleMenu) this.gameLogic.toggleMenu('options');
 
             if (e.code.startsWith('Digit')) {
                 const index = parseInt(e.code.replace('Digit', '')) - 1;

--- a/game.js
+++ b/game.js
@@ -124,6 +124,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             case 'options': showMenu(ui.optionsMenu); break;
             case 'backToMain': showMenu(ui.mainMenu); break;
             case 'closeMenu': toggleMenu(false, 'controls'); break;
+            case 'closeOptions': toggleMenu(false, 'options'); break;
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -192,6 +192,7 @@
                 </div>
                 <input type="range" id="soundSlider" min="0" max="1" step="0.1" value="0.8" style="width: 100%;">
 
+                <button data-action="closeOptions">RETOUR AU JEU</button>
                 <button data-action="backToMain">RETOUR</button>
             </div>
         </div>
@@ -201,7 +202,7 @@
                 <h2>COMMANDES</h2>
                 <b>MOUVEMENT:</b><br>- GAUCHE/DROITE: Flèches directionnelles<br>- SAUTER: Espace / Flèche du haut<br><br>
                 <b>ACTIONS:</b><br>- UTILISER OBJET: Touche 'A' ou Clic Gauche<br>- CHANGER D'OBJET: Touches 1 à 6<br><br>
-                <b>JEU:</b><br>- AFFICHER/CACHER CE MENU: Touche 'C'<br>- OPTIONS: Touche 'O'
+                <b>JEU:</b><br>- AFFICHER/CACHER CE MENU: Touche 'C'<br>- OPTIONS: Touche 'O' ou Échap
                 <button data-action="closeMenu">RETOUR AU JEU</button>
             </div>
         </div>

--- a/player.js
+++ b/player.js
@@ -13,9 +13,12 @@ const TILE_HARDNESS = {
 
 // Tools effective against certain block types
 const TOOL_EFFECTIVENESS = {
-    'shovel': [TILE.GRASS, TILE.DIRT],
-    'axe': [TILE.WOOD, TILE.LEAVES],
-    'pickaxe': [TILE.STONE, TILE.COAL, TILE.IRON]
+    shovel: [TILE.GRASS, TILE.DIRT],
+    axe: [TILE.WOOD, TILE.LEAVES],
+    pickaxe: [TILE.STONE, TILE.COAL, TILE.IRON],
+    sword: [TILE.LEAVES],
+    bow: [TILE.GRASS],
+    fishing_rod: [TILE.WOOD, TILE.LEAVES]
 };
 
 export class Player {


### PR DESCRIPTION
## Summary
- allow Escape key to toggle the options menu
- add a button to close options and resume the game
- document Escape key in controls
- define specific block effectiveness for all tools

## Testing
- `node --check engine.js`
- `node --check game.js`
- `node --check player.js`

------
https://chatgpt.com/codex/tasks/task_e_688b5466e744832b9a4e19b5a81a44a3