### PR TITLE
Add mouse-wheel equipment cycling

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -83,6 +83,14 @@ export class GameEngine {
             if (e.button === 0) this.mouse.left = true;
             if (e.button === 2) this.mouse.right = true;
         });
+        this.canvas.addEventListener('wheel', e => {
+            if (this.gameLogic.isPaused && this.gameLogic.isPaused()) return;
+            if (this.gameLogic.cycleTool) {
+                if (e.deltaY < 0) this.gameLogic.cycleTool(-1);
+                else if (e.deltaY > 0) this.gameLogic.cycleTool(1);
+            }
+            e.preventDefault();
+        });
         this.canvas.addEventListener('contextmenu', e => e.preventDefault());
     }
 

--- a/game.js
+++ b/game.js
@@ -531,6 +531,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 game.player.selectedToolIndex = index;
             }
         },
+        cycleTool: (dir) => {
+            if (game.player) {
+                const len = game.player.tools.length;
+                game.player.selectedToolIndex = (game.player.selectedToolIndex + dir + len) % len;
+            }
+        },
         showError: (error) => {
             logger.error(error.message);
             if(ui.mainMenu) ui.mainMenu.innerHTML = `<h2>Erreur de chargement.</h2><p style="font-size:0.5em;">${error}</p>`;

--- a/player.js
+++ b/player.js
@@ -89,7 +89,7 @@ export class Player {
     }
 
     handleActions(keys, mouse, game) {
-        const isAction = keys.action || mouse.left;
+        const isAction = keys.action || mouse.left || mouse.right;
         const selectedTool = this.tools[this.selectedToolIndex];
 
         if (isAction) {
@@ -134,7 +134,7 @@ export class Player {
 
 // Use mouse if pressed, otherwise check blocks around/in front of the player
 
-        if (mouse.left) {
+        if (mouse.left || mouse.right) {
             const worldMouseX = mouse.x / game.settings.zoom + game.camera.x;
             const worldMouseY = mouse.y / game.settings.zoom + game.camera.y;
             tileX = Math.floor(worldMouseX / tileSize);


### PR DESCRIPTION
## Summary
- support cycling tools with mouse wheel
- allow right-click to perform actions

## Testing
- `node -c engine.js`
- `node -c game.js`
- `node -c player.js`


------
https://chatgpt.com/codex/tasks/task_e_688b59079e58832badb4ca0c636aff6a