### PR TITLE
Enable custom player skin

### DIFF
--- a/creator.js
+++ b/creator.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const partsContainer = document.getElementById('creatorParts');
   const previewCanvas = document.getElementById('creatorPreview');
   const downloadBtn = document.getElementById('creatorDownload');
-  if (!partsContainer || !previewCanvas || !downloadBtn) return;
+  const saveBtn = document.getElementById('creatorSave');
+  if (!partsContainer || !previewCanvas || !downloadBtn || !saveBtn) return;
 
   const PARTS = [
     { key: 'head',      label: 'T\u00eate',       styles: ['Classique','Carr\u00e9e','Ronde'], defaultColor: '#ffe0b0' },
@@ -140,5 +141,13 @@ document.addEventListener('DOMContentLoaded', () => {
     link.href = previewCanvas.toDataURL();
     link.download = 'pixel_personnage.png';
     link.click();
+  });
+
+  saveBtn.addEventListener('click', () => {
+    const data = previewCanvas.toDataURL();
+    try {
+      localStorage.setItem('customPlayer1', data);
+    } catch(e) {}
+    location.reload();
   });
 });

--- a/engine.js
+++ b/engine.js
@@ -26,9 +26,13 @@ export class GameEngine {
         }
         this.config.skins.forEach((fileName, i) => {
             const skinPath = 'assets/' + fileName;
-            // CORRECTION: On utilise aussi le chemin relatif simple ici
             allAssetPaths[`player${i+1}`] = baseUrl ? baseUrl + skinPath : skinPath;
         });
+
+        const custom = localStorage.getItem('customPlayer1');
+        if (custom) {
+            allAssetPaths['player1'] = custom;
+        }
 
         for (const [key, path] of Object.entries(allAssetPaths)) {
             promises.push(new Promise((resolve) => { // On utilise resolve dans tous les cas

--- a/index.html
+++ b/index.html
@@ -45,7 +45,8 @@
             width: 100%;
             height: 100%;
         }
-        canvas {
+        /* Le canvas du jeu occupe tout l'espace */
+        #gameCanvas {
             display: block;
             width: 100%;
             height: 100%;
@@ -151,7 +152,14 @@
         .creator-part { background:#1a1b1e; border-radius:7px; padding:7px 10px; margin:2px; }
         #creatorMenu label { font-size:.95em; color:#ffe01b; }
         #creatorMenu select, #creatorMenu input[type=color] { margin-top:3px; margin-bottom:2px; }
-        #creatorPreview { background:#191b22; border:2px solid #ffe01b; margin:14px auto; image-rendering:pixelated; }
+        #creatorPreview {
+            width: 96px;
+            height: 96px;
+            background:#191b22;
+            border:2px solid #ffe01b;
+            margin:14px auto;
+            image-rendering:pixelated;
+        }
         #creatorDownload { margin-top:12px; background:#ffe01b; color:#181b2a; font-weight:bold; border-radius:8px; border:none; padding:8px 20px; font-size:1em; cursor:pointer; }
     </style>
 </head>
@@ -221,6 +229,7 @@
                 <div id="creatorParts"></div>
                 <canvas id="creatorPreview" width="48" height="48"></canvas><br>
                 <button id="creatorDownload">Télécharger PNG</button>
+                <button id="creatorSave">Utiliser ce personnage</button>
                 <button data-action="backToMain">RETOUR</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- adjust global canvas style to avoid huge preview and size the character preview
- add Save button in creator menu to retexture player 1 and reload
- load custom player skin from `localStorage` when the engine loads

## Testing
- `node -c creator.js`
- `node -c engine.js`

------
https://chatgpt.com/codex/tasks/task_e_688b5ab7d540832b970d98d362d5228c