### PR TITLE
Fix menu toggle condition

### DIFF
--- a/game.js
+++ b/game.js
@@ -251,7 +251,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function toggleMenu(show, menuType) {
-        if (!game || !gameSettings.showParticles) return;
+        if (!game) return;
         game.paused = show;
         let menuToToggle = menuType === 'options' ? ui.optionsMenu : ui.controlsMenu;
         if (show) {


### PR DESCRIPTION
## Summary
- remove incorrect `showParticles` check when toggling menus

## Testing
- `node --check game.js`
- `for f in *.js; do node --check "$f"; done`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_688b7c1f61e0832bb5ee23d7ec095a61