### PR TITLE
Fix missing player asset crash

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -54,21 +54,23 @@
              allAssetPaths['player1'] = custom;
          }
  
-         for (const [key, path] of Object.entries(allAssetPaths)) {
-             promises.push(new Promise((resolve) => { // On utilise resolve dans tous les cas
-                 const img = new Image();
-                 img.crossOrigin = "Anonymous";
-                 img.src = path;
-                 img.onload = () => {
-                     this.assets[key] = img;
-                     resolve({ status: 'fulfilled', value: key });
-                 };
-                 img.onerror = () => {
-                     console.warn(`Impossible de charger l'asset: ${path}`); // Affiche une alerte mais ne bloque pas
-                     resolve({ status: 'rejected', reason: key });
-                 };
-             }));
-         }
+        for (const [key, path] of Object.entries(allAssetPaths)) {
+            promises.push(new Promise((resolve) => {
+                const img = new Image();
+                img.crossOrigin = "Anonymous";
+                img.src = path;
+                img.onload = () => {
+                    this.assets[key] = img;
+                    resolve({ status: 'fulfilled', value: key });
+                };
+                img.onerror = () => {
+                    console.warn(`Impossible de charger l'asset: ${path}`);
+                    const placeholder = new Image();
+                    this.assets[key] = placeholder;
+                    resolve({ status: 'rejected', reason: key });
+                };
+            }));
+        }
          await Promise.all(promises); // Attend que toutes les tentatives de chargement soient terminées
      }
  

--- a/game.js
+++ b/game.js
@@ -71,7 +71,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!ui.mainMenu) { initGame(); return; }
         ui.skinlist.innerHTML = '';
         config.skins.forEach((_, i) => {
-            const img = assets[`player${i+1}`].cloneNode();
+            const asset = assets[`player${i+1}`];
+            if (!asset) {
+                logger.error(`Skin player${i+1} manquant`);
+                return;
+            }
+            const img = asset.cloneNode();
             img.onclick = () => selectSkin(i);
             if (i === currentSkin) img.classList.add("selected");
             ui.skinlist.appendChild(img);


### PR DESCRIPTION
## Summary
- avoid crash when player images fail to load
- guard skin menu against missing assets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b80338838832b83cccb684624cf85