### PR TITLE
Fix invalid array length during init

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,8 @@
    "tileSize": 16,
    "zoom": 1,
    "chunkSize": 16,
+   "worldWidth": 3000,
+   "worldHeight": 540,
    "renderDistance": 8,
    "showParticles": true,
    "weatherEffects": true,


### PR DESCRIPTION
## Summary
- define `worldWidth` and `worldHeight` in `config.json` to ensure level generation has valid dimensions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b89eb5614832b8699441a53a39423