### PR TITLE
Add mining engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Physique Réaliste : Le moteur physique a été amélioré avec une gestion de l
 Gameplay Approfondi :
 
 Ennemis Variés : Affrontez 3 types d'ennemis avec des comportements uniques.
+Moteur de minage : cassez les blocs du terrain avec vos outils et récoltez les ressources.
 
 Animations Dynamiques : le héros adopte maintenant des postures
 différentes lorsqu'il marche, saute ou vole, offrant un rendu plus vivant.
@@ -28,6 +29,10 @@ Interface enrichie :
 - Inventaire complet (touche **I**).
 - Menu des compétences (touche **P**).
 - Menu des commandes remis à jour.
+
+## Cassage de blocs
+
+Le module `miningEngine.js` gère la destruction des tuiles. Maintenez l'action sur un bloc pour remplir la jauge de minage. Une fois pleine, le bloc se transforme en objet collectable qui rejoint l'inventaire au contact du joueur (`player.inventory`). Intégrez simplement le moteur en appelant `updateMining(game, keys, mouse)` à chaque frame.
 
 🚀 Comment Lancer le Jeu
 Vérifiez votre dépôt GitHub : Assurez-vous que le dossier assets de votre dépôt GitHub contient bien tous les fichiers images listés.

--- a/game.js
+++ b/game.js
@@ -4,6 +4,7 @@ import { generateLevel, TILE } from './world.js';
 import { Logger } from './logger.js';
 import { WorldAnimator } from './worldAnimator.js';
 import { SoundManager } from './sound.js';
+import { updateMining } from './miningEngine.js';
 import { randomItem } from './survivalItems.js';
 import { getItemIcon } from './itemIcons.js';
 import { getChestImage } from './chestGenerator.js';
@@ -216,6 +217,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             updateParticles();
             updateFallingBlocks();
             updateCollectibles();
+            updateMining(game, keys, mouse);
             updateCamera(false);
             if (worldAnimator) worldAnimator.update(game.camera, ui.canvas, gameSettings.zoom);
             if (keys.action) keys.action = false;

--- a/miningEngine.js
+++ b/miningEngine.js
@@ -1,0 +1,87 @@
+import { TILE } from './world.js';
+
+const BLOCK_BREAK_TIME = {
+    [TILE.GRASS]: 0.5,
+    [TILE.DIRT]: 1,
+    [TILE.STONE]: 2,
+    [TILE.WOOD]: 1.5,
+    [TILE.LEAVES]: 0.3,
+    [TILE.COAL]: 2.5,
+    [TILE.IRON]: 3.5,
+};
+
+const TOOL_EFFICIENCY = {
+    pickaxe: { [TILE.STONE]: 3, [TILE.COAL]: 3, [TILE.IRON]: 3 },
+    shovel: { [TILE.DIRT]: 3, [TILE.GRASS]: 3 },
+    axe:    { [TILE.WOOD]: 3, [TILE.LEAVES]: 3 },
+    hand:   { [TILE.GRASS]: 1, [TILE.DIRT]: 0.5 },
+};
+
+let lastTime = performance.now();
+
+export function updateMining(game, keys, mouse) {
+    const now = performance.now();
+    const delta = (now - lastTime) / 1000;
+    lastTime = now;
+
+    const player = game.player;
+    if (!player) return;
+
+    const isAction = keys.action || mouse.left || mouse.right;
+    const target = player.miningTarget;
+
+    if (!isAction || !target) {
+        player.miningTarget = isAction ? target : null;
+        player.miningProgress = 0;
+        game.miningEffect = null;
+        return;
+    }
+
+    const currentType = game.tileMap[target.y]?.[target.x];
+    if (currentType !== target.type || currentType === TILE.AIR) {
+        player.miningTarget = null;
+        player.miningProgress = 0;
+        game.miningEffect = null;
+        return;
+    }
+
+    const toolName = player.tools[player.selectedToolIndex] || 'hand';
+    const breakTime = BLOCK_BREAK_TIME[currentType] || 1;
+    const eff = TOOL_EFFICIENCY[toolName]?.[currentType];
+    const efficiency = eff !== undefined ? eff : (toolName === 'hand' ? 0.2 : 0.5);
+    if (efficiency <= 0) {
+        game.miningEffect = null;
+        return;
+    }
+
+    const timeToBreak = breakTime / efficiency;
+    player.miningProgress += delta / timeToBreak;
+    game.miningEffect = { x: target.x, y: target.y, progress: player.miningProgress };
+
+    if (player.miningProgress >= 1) {
+        destroyBlock(game, target.x, target.y, currentType);
+        player.miningProgress = 0;
+        player.miningTarget = null;
+        game.miningEffect = null;
+    }
+}
+
+function destroyBlock(game, x, y, type) {
+    const { tileSize } = game.config;
+    game.tileMap[y][x] = TILE.AIR;
+    game.sound?.playBreak();
+    game.createParticles(x * tileSize + tileSize / 2, y * tileSize + tileSize / 2, 5, '#ccc');
+
+    game.collectibles.push({
+        x: x * tileSize,
+        y: y * tileSize,
+        w: tileSize,
+        h: tileSize,
+        vy: -2,
+        tileType: type
+    });
+
+    if ((type === TILE.WOOD || type === TILE.LEAVES) && game.propagateTreeCollapse) {
+        game.propagateTreeCollapse(x, y);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `miningEngine.js` for breaking tiles
- call mining update in the game loop
- import the new module
- document mining in README

## Testing
- `node -e "import('./miningEngine.js').then(m=>console.log('loaded'))" --experimental-modules`


------
https://chatgpt.com/codex/tasks/task_e_688b90c08208832bb902d85176958d27