### PR TITLE
Add knife tool and document available tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Interface enrichie :
 
 Le module `miningEngine.js` gère la destruction des tuiles. Maintenez l'action sur un bloc pour remplir la jauge de minage. Une fois pleine, le bloc se transforme en objet collectable qui rejoint l'inventaire au contact du joueur (`player.inventory`). Intégrez simplement le moteur en appelant `updateMining(game, keys, mouse)` à chaque frame.
 
+### Outils disponibles
+
+Les outils utilisables pour casser les blocs disposent chacun de leur icône dans le dossier `assets`. La barre d'outils affiche par défaut :
+
+- la pioche (`tool_pickaxe.png`)
+- la pelle (`tool_shovel.png`)
+- la hache (`tool_axe.png`)
+- le couteau (`tool_knife.png`)
+- l'épée (`tool_sword.png`)
+- l'arc (`tool_bow.png`)
+- la canne à pêche (`tool_fishing_rod.png`)
+
 🚀 Comment Lancer le Jeu
 Vérifiez votre dépôt GitHub : Assurez-vous que le dossier assets de votre dépôt GitHub contient bien tous les fichiers images listés.
 

--- a/player.js
+++ b/player.js
@@ -17,8 +17,9 @@ export class Player {
          this.state = 'idle';
          this.animTimer = 0;
          this.animFrame = 0;
-         // Tool list (axe reintroduced for tree cutting)
-         this.tools = ['pickaxe', 'shovel', 'axe', 'sword', 'bow', 'fishing_rod'];
+        // Tool list including the basic weapons that can be used for mining
+        // Tools correspond to the icons located in assets/tool_*.png
+        this.tools = ['pickaxe', 'shovel', 'axe', 'knife', 'sword', 'bow', 'fishing_rod'];
          this.selectedToolIndex = 0;
          this.inventory = {};
          this.miningTarget = null;


### PR DESCRIPTION
## Summary
- include the knife in the player's default tool list
- document the list of available tools in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bc5651dd8832b865b7ca034551e2a