### PR TITLE
Adjust player size and spawn height

### DIFF
--- a/config.json
+++ b/config.json
@@ -32,14 +32,14 @@
   },
    "player": {
      "maxLives": 5,
-    "width": 96,
-    "height": 96,
+    "width": 64,
+    "height": 64,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 16,
-      "offsetY": 12,
-      "width": 64,
-      "height": 72
+      "offsetX": 10,
+      "offsetY": 8,
+      "width": 44,
+      "height": 48
     },
      "reach": 4,
      "attackRange": 20

--- a/game.js
+++ b/game.js
@@ -530,9 +530,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const spawnX = Math.floor(worldWidthInTiles / 2);
 
         const playerTiles = Math.ceil(config.player.height / tileSize);
+        const extraOffset = 10; // spawn higher so the player falls onto the ground
         for (let y = 0; y < game.tileMap.length; y++) {
             if (game.tileMap[y] && game.tileMap[y][spawnX] > 0) {
-                const offset = playerTiles + 1;
+                const offset = playerTiles + 1 + extraOffset;
                 return { x: spawnX * tileSize, y: Math.max(0, (y - offset) * tileSize) };
             }
         }

--- a/generateurAnimaux.js
+++ b/generateurAnimaux.js
@@ -567,9 +567,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const spawnX = Math.floor(worldWidthInTiles / 2);
 
         const playerTiles = Math.ceil(config.player.height / tileSize);
+        const extraOffset = 10; // spawn higher so the player falls onto the ground
         for (let y = 0; y < game.tileMap.length; y++) {
             if (game.tileMap[y] && game.tileMap[y][spawnX] > 0) {
-                const offset = playerTiles + 1;
+                const offset = playerTiles + 1 + extraOffset;
                 return { x: spawnX * tileSize, y: Math.max(0, (y - offset) * tileSize) };
             }
         }


### PR DESCRIPTION
## Summary
- make the player sprite smaller and update hitbox
- spawn player higher above the ground so it falls down

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ca87f13ac832b9c05cced931ab723