### PR TITLE
Fix enemy assets error

### DIFF
--- a/game.js
+++ b/game.js
@@ -549,7 +549,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             drawChests(ctx, assets);
             
             game.animals.forEach(a => a.draw(ctx));
-            game.enemies.forEach(e => e.draw(ctx));
+            game.enemies.forEach(e => e.draw(ctx, assets));
             game.pnjs.forEach(p => p.draw(ctx));
             game.player.draw(ctx, assets, `player${currentSkin + 1}`);
             if (debugMode) {


### PR DESCRIPTION
## Summary
- pass `assets` object when drawing enemies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688caf6db32c832bb6c94a30cad3907f