### PR TITLE
Fix spawn height and mining

### DIFF
--- a/config.json
+++ b/config.json
@@ -32,14 +32,14 @@
   },
    "player": {
      "maxLives": 5,
-    "width": 48,
-    "height": 48,
+    "width": 32,
+    "height": 32,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 8,
-      "offsetY": 6,
-      "width": 32,
-      "height": 36
+      "offsetX": 4,
+      "offsetY": 4,
+      "width": 24,
+      "height": 24
     },
      "reach": 4,
      "attackRange": 20

--- a/game.js
+++ b/game.js
@@ -265,7 +265,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         return BLOCK_RESISTANCE[tileType] || 100;
     }
     
-    function handleMining(game, mouse) {
+    function handleMining(game, keys, mouse) {
         const { tileSize } = game.config;
         const { player } = game;
         const mouseWorldX = mouse.x / game.settings.zoom + game.camera.x;
@@ -278,7 +278,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
         const tileType = game.tileMap[tileY]?.[tileX];
-        if (!mouse.left || !tileType || tileType === TILE.AIR) {
+        const isMining = mouse.left || keys.action;
+        if (!isMining || !tileType || tileType === TILE.AIR) {
             game.miningEffect = null;
             return;
         }
@@ -517,7 +518,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             updateParticles();
             updateFallingBlocks();
             updateCollectibles();
-            handleMining(game, mouse);
+            handleMining(game, keys, mouse);
             updateCamera(false);
             if (worldAnimator) worldAnimator.update(game.camera, ui.canvas, gameSettings.zoom);
             
@@ -599,9 +600,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const spawnX = Math.floor(worldWidthInTiles / 2);
 
         const playerTiles = Math.ceil(config.player.height / tileSize);
+        const extraOffset = 10; // spawn higher so the player falls onto the ground
         for (let y = 0; y < game.tileMap.length; y++) {
             if (game.tileMap[y] && game.tileMap[y][spawnX] > 0) {
-                const offset = playerTiles + 1;
+                const offset = playerTiles + 1 + extraOffset;
                 return { x: spawnX * tileSize, y: Math.max(0, (y - offset) * tileSize) };
             }
         }


### PR DESCRIPTION
## Summary
- spawn the player higher to avoid overlapping blocks
- enable mining with the `A` key as well as mouse
- reduce player size in config for better proportions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cb29cc1b4832ba702cd9e106679e8