### PR TITLE
Fix missing sound play and guard enemy collisions

### DIFF
--- a/player.js
+++ b/player.js
@@ -209,9 +209,11 @@ export class Player {
         };
 
         for (const enemy of game.enemies) {
-            if (enemy.isDead || enemy.isDying) continue;
-            if (enemy.rectCollide(attackBox)) {
-                enemy.takeDamage(game, this.getDamage());
+            if (!enemy || enemy.isDead || enemy.isDying) continue;
+            if (typeof enemy.rectCollide === 'function' && enemy.rectCollide(attackBox)) {
+                if (typeof enemy.takeDamage === 'function') {
+                    enemy.takeDamage(game, this.getDamage());
+                }
             }
         }
     }

--- a/sound.js
+++ b/sound.js
@@ -76,5 +76,24 @@ export class SoundManager {
         }
     }
 
+    /**
+     * Generic play method used by the rest of the game. Since this project
+     * only uses synthesized tones, map known effect names to a short tone.
+     * Unknown names are ignored to avoid runtime errors.
+     */
+    play(name, opts = {}) {
+        const volume = opts.volume ?? 1;
+        switch (name) {
+            case 'enemy_die':
+                this.playTone(200, 0.2, 'square', 0.1 * volume);
+                break;
+            case 'break_block':
+                this.playTone(180, 0.15, 'square', 0.1 * volume);
+                break;
+            default:
+                console.warn(`Unknown sound: ${name}`);
+        }
+    }
+
     update() { if (this.stepCooldown > 0) this.stepCooldown--; }
 }


### PR DESCRIPTION
## Summary
- prevent errors when enemies lack collision methods
- add a `play` helper to `SoundManager`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cb3d47840832bbcb6e82da846a7a7