### PR TITLE
Reduce blurry display and adjust tool size

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Ouvrez index.html : Lancez ce fichier dans un navigateur web moderne.
 Jouez ! Le jeu chargera les assets depuis votre GitHub et sera prêt à jouer.
 
 Astuce : appuyez sur **F3** en jeu pour activer le mode debug (FPS et hitbox).
+
+### Nouveautés graphiques
+- Le canvas ajuste maintenant automatiquement sa taille à la fenêtre pour un affichage net.
+- Le héros est plus petit et les outils visibles dans ses mains sont quatre fois réduits.

--- a/config.json
+++ b/config.json
@@ -32,14 +32,14 @@
   },
    "player": {
      "maxLives": 5,
-    "width": 32,
-    "height": 32,
+    "width": 24,
+    "height": 24,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 4,
-      "offsetY": 4,
-      "width": 24,
-      "height": 24
+      "offsetX": 3,
+      "offsetY": 3,
+      "width": 18,
+      "height": 18
     },
      "reach": 4,
      "attackRange": 20

--- a/engine.js
+++ b/engine.js
@@ -2,7 +2,9 @@
  export class GameEngine {
      constructor(canvas, config) {
          this.canvas = canvas;
-         this.ctx = canvas.getContext('2d');
+        this.ctx = canvas.getContext('2d');
+        // Disable smoothing for crisp pixel art
+        this.ctx.imageSmoothingEnabled = false;
          this.config = config;
          this.assets = {};
         this.keys = {

--- a/game.js
+++ b/game.js
@@ -176,6 +176,13 @@ class Animal {
 
 document.addEventListener('DOMContentLoaded', async () => {
     const canvas = document.getElementById('gameCanvas');
+    // Match canvas resolution with the window size to avoid blurring
+    function resizeCanvas() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+    }
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
     const config = await (await fetch('config.json')).json();
     const logger = new Logger();
     const sound = new SoundManager(config.soundVolume);

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             height: 100%;
             background: transparent;
             transition: filter 0.3s ease-in-out;
+            image-rendering: pixelated;
         }
         #gameCanvas.paused {
             filter: blur(4px) grayscale(50%);

--- a/player.js
+++ b/player.js
@@ -380,7 +380,8 @@ export class Player {
             if (toolAsset) {
                 ctx.save();
                 
-                const toolSize = this.w * 0.8;
+                // Tools are now scaled down for better proportions
+                const toolSize = this.w * 0.2;
                 const handOffsetX = this.dir === 1 ? this.w * 0.7 : this.w * 0.3;
                 const handOffsetY = this.h * 0.6;
                 const pivotX = this.x + handOffsetX;


### PR DESCRIPTION
## Summary
- disable canvas image smoothing in `GameEngine`
- set canvas resolution to match the window
- shrink player dimensions in `config.json`
- render tools 4x smaller
- enforce pixelated rendering on `#gameCanvas`
- document the changes in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cb5593c3c832b9404b57dd410c89c