### PR TITLE
Fix extreme zoom and hitbox values

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "tileSize": 16,
-  "zoom": 100,
+  "zoom": 3,
   "chunkSize": 16,
   "worldWidth": 3008,
   "worldHeight": 4096,
@@ -38,8 +38,8 @@
     "hitbox": {
       "offsetX": 3,
       "offsetY": 3,
-      "width": 0.0001,
-      "height": 0.0001
+      "width": 18,
+      "height": 18
     },
     "reach": 4,
     "attackRange": 20

--- a/game.js
+++ b/game.js
@@ -140,7 +140,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let lastFrame = performance.now();
     let cameraShake = { intensity: 0, duration: 0 };
     let stars = [];
-    const CAMERA_SMOOTHING = 1;
+    const CAMERA_SMOOTHING = 0.5;
     const defaultGravity = config.physics.gravity;
 
     const TOOL_DATA = {

--- a/index.html
+++ b/index.html
@@ -433,9 +433,9 @@
                 <input type="range" id="renderDistanceSlider" min="4" max="16" value="8" style="width: 100%;">
                 <div class="option-group" style="margin-top: 20px;">
                     <label>Zoom</label>
-                    <span id="zoomValue">x100</span>
+                    <span id="zoomValue">x3</span>
                 </div>
-                <input type="range" id="zoomSlider" min="0.5" max="100" value="100" step="0.25" style="width: 100%;">
+                <input type="range" id="zoomSlider" min="0.5" max="4" value="3" step="0.25" style="width: 100%;">
                 <div class="option-group" style="margin-top:20px;">
                     <label><input type="checkbox" id="particlesCheckbox"> Particules</label>
                 </div>


### PR DESCRIPTION
## Summary
- reset camera smoothing to a reasonable speed
- restore normal zoom level and slider
- return player hitbox values to normal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ce84b73b0832ba3f0bb4639bad857