### PR TITLE
Fix hitbox and zoom defaults

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,8 +38,8 @@
     "hitbox": {
       "offsetX": 3,
       "offsetY": 3,
-      "width": 0.0001,
-      "height": 0.0001
+      "width": 18,
+      "height": 18
     },
     "reach": 4,
     "attackRange": 20

--- a/index.html
+++ b/index.html
@@ -433,9 +433,9 @@
                 <input type="range" id="renderDistanceSlider" min="4" max="16" value="8" style="width: 100%;">
                 <div class="option-group" style="margin-top: 20px;">
                     <label>Zoom</label>
-                    <span id="zoomValue">x100</span>
+                    <span id="zoomValue">x20</span>
                 </div>
-                <input type="range" id="zoomSlider" min="0.5" max="100" value="100" step="0.25" style="width: 100%;">
+                <input type="range" id="zoomSlider" min="0.5" max="20" value="20" step="0.25" style="width: 100%;">
                 <div class="option-group" style="margin-top:20px;">
                     <label><input type="checkbox" id="particlesCheckbox"> Particules</label>
                 </div>


### PR DESCRIPTION
## Summary
- restore full player hitbox values
- update menu defaults to match new zoom level

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ce9619d48832bb509a68f4cc3b994