### PR TITLE
Fix tool names for assets

### DIFF
--- a/generateurQuete.js
+++ b/generateurQuete.js
@@ -15,7 +15,9 @@ const MONSTERS = {
     hell: [{ id: 'monster_hell', name: 'Démon' }],
 };
 
-const TOOLS = [{ id: 'stone_pickaxe', name: 'Pioche en Pierre' }, { id: 'iron_axe', name: 'Hache en Fer' }];
+// Les quêtes doivent référencer les mêmes identifiants d'outils que le joueur.
+// On retire le préfixe "stone_" pour rester cohérent avec les assets.
+const TOOLS = [{ id: 'pickaxe', name: 'Pioche en Pierre' }, { id: 'iron_axe', name: 'Hache en Fer' }];
 
 // --- MODÈLES DE QUÊTES PAR ARCHÉTYPE ---
 

--- a/player.js
+++ b/player.js
@@ -31,7 +31,10 @@ export class Player {
         this.animFrame = 0;
         
         // --- CORRECTION: Utiliser des noms d'outils valides ---
-        this.tools = ['stone_pickaxe', 'stone_shovel', 'stone_axe', 'knife', 'sword', 'bow', 'fishing_rod'];
+        // Les noms doivent correspondre aux clés d'asset et aux outils
+        // utilisés dans miningEngine.js. Les préfixes "stone_" empêchaient
+        // de charger les bonnes icônes et rendait le minage moins efficace.
+        this.tools = ['pickaxe', 'shovel', 'axe', 'knife', 'sword', 'bow', 'fishing_rod'];
         this.selectedToolIndex = 0;
         this.inventory = {};
         this.quests = [];
@@ -200,7 +203,8 @@ export class Player {
             }
         }
 
-        const attackTools = ['sword', 'knife', 'stone_axe', 'stone_pickaxe'];
+        // Les noms doivent rester cohérents avec this.tools
+        const attackTools = ['sword', 'knife', 'axe', 'pickaxe'];
         const selectedTool = this.tools[this.selectedToolIndex];
         if (mouse.left && attackTools.some(t => selectedTool.includes(t)) && this.swingTimer <= 0) {
             this.swingTimer = 30;


### PR DESCRIPTION
## Summary
- align player tool list with asset names
- adjust attack tool checks
- update quest generator tool names

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ceb2893d4832bbe8352442f5f3357