### PR TITLE
Add mobile mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Interface enrichie :
 - Inventaire complet (touche **I**).
 - Menu des compétences (touche **P**).
 - Menu des commandes remis à jour.
+- Mode mobile activable depuis les options.
 
 ## Cassage de blocs
 

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
   "weatherEffects": true,
   "dynamicLighting": true,
   "soundVolume": 0.8,
+  "mobileMode": false,
   "generation": {
     "enemyCount": 50,
     "treeCount": 40,

--- a/game.js
+++ b/game.js
@@ -35,6 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const particlesCheckbox = document.getElementById('particlesCheckbox');
     const weatherCheckbox = document.getElementById('weatherCheckbox');
     const lightingCheckbox = document.getElementById('lightingCheckbox');
+    const mobileModeCheckbox = document.getElementById('mobileModeCheckbox');
     const soundSlider = document.getElementById('soundSlider');
     const volumeValue = document.getElementById('volumeValue');
 
@@ -46,6 +47,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     particlesCheckbox.checked = config.showParticles;
     weatherCheckbox.checked = config.weatherEffects;
     lightingCheckbox.checked = config.dynamicLighting;
+    mobileModeCheckbox.checked = config.mobileMode;
+    if (config.mobileMode) document.body.classList.add('mobile-mode');
     soundSlider.value = config.soundVolume;
     volumeValue.textContent = `${Math.round(config.soundVolume * 100)}%`;
 
@@ -67,6 +70,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     lightingCheckbox.addEventListener('change', () => {
         config.dynamicLighting = lightingCheckbox.checked;
     });
+    mobileModeCheckbox.addEventListener('change', () => {
+        config.mobileMode = mobileModeCheckbox.checked;
+        document.body.classList.toggle('mobile-mode', config.mobileMode);
+    });
     soundSlider.addEventListener('input', () => {
         config.soundVolume = parseFloat(soundSlider.value);
         volumeValue.textContent = `${Math.round(config.soundVolume * 100)}%`;
@@ -87,7 +94,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             showParticles: config.showParticles,
             weatherEffects: config.weatherEffects,
             dynamicLighting: config.dynamicLighting,
-            soundVolume: config.soundVolume
+            soundVolume: config.soundVolume,
+            mobileMode: config.mobileMode
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -44,6 +44,13 @@
         #gameCanvas.paused {
             filter: blur(4px) grayscale(50%);
         }
+        body.mobile-mode #gameCanvas {
+            width: 100vw;
+            height: 100vh;
+        }
+        body.mobile-mode .menu-box button {
+            font-size: 1.2em;
+        }
 
         /* --- NOUVEL ÉCRAN TITRE AMÉLIORÉ --- */
         @keyframes ken-burns {
@@ -445,6 +452,9 @@
                 </div>
                 <div class="option-group">
                     <label><input type="checkbox" id="lightingCheckbox"> Lumière dynamique</label>
+                </div>
+                <div class="option-group">
+                    <label><input type="checkbox" id="mobileModeCheckbox"> Mode Mobile</label>
                 </div>
                 <div class="option-group" style="margin-top:20px;">
                     <label>Volume</label>

--- a/options.json
+++ b/options.json
@@ -4,5 +4,6 @@
   "showParticles": true,
   "weatherEffects": true,
   "dynamicLighting": true,
-  "soundVolume": 0.8
+  "soundVolume": 0.8,
+  "mobileMode": false
 }


### PR DESCRIPTION
## Summary
- add `mobileMode` option in config and saved options
- allow toggling mobile mode in Options menu
- update CSS and README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d15d49c70832bb4735eaa10529ada