### PR TITLE
Add mobile touch controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Interface enrichie :
 - Inventaire complet (touche **I**).
 - Menu des compétences (touche **P**).
 - Menu des commandes remis à jour.
-- Mode mobile activable depuis les options.
+- Mode mobile activable depuis les options avec commandes tactiles.
 
 ## Cassage de blocs
 
@@ -64,6 +64,9 @@ Ouvrez index.html : Lancez ce fichier dans un navigateur web moderne.
 Jouez ! Le jeu chargera les assets depuis votre GitHub et sera prêt à jouer.
 
 Astuce : appuyez sur **F3** en jeu pour activer le mode debug (FPS et hitbox).
+
+### Mode Mobile
+Activez le mode mobile dans le menu Options pour afficher des boutons tactiles (gauche, droite, saut et action) et jouer confortablement sur smartphone.
 
 ### Nouveautés graphiques
 - Le canvas ajuste maintenant automatiquement sa taille à la fenêtre pour un affichage net.

--- a/engine.js
+++ b/engine.js
@@ -144,6 +144,48 @@ export class GameEngine {
             e.preventDefault();
         });
         this.canvas.addEventListener('contextmenu', e => e.preventDefault());
+
+        // Support tactile pour le mobile
+        const touchMap = [
+            ['btnLeft', 'left'],
+            ['btnRight', 'right'],
+            ['btnJump', 'jump'],
+            ['btnAction', 'action']
+        ];
+        touchMap.forEach(([id, key]) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.addEventListener('touchstart', e => {
+                this.keys[key] = true;
+                e.preventDefault();
+            });
+            el.addEventListener('touchend', e => {
+                this.keys[key] = false;
+                e.preventDefault();
+            });
+            el.addEventListener('touchcancel', e => {
+                this.keys[key] = false;
+                e.preventDefault();
+            });
+        });
+        this.canvas.addEventListener('touchstart', e => {
+            if (this.gameLogic.isPaused && this.gameLogic.isPaused()) return;
+            const rect = this.canvas.getBoundingClientRect();
+            const touch = e.touches[0];
+            this.mouse.x = touch.clientX - rect.left;
+            this.mouse.y = touch.clientY - rect.top;
+            this.mouse.left = true;
+            e.preventDefault();
+        });
+        this.canvas.addEventListener('touchmove', e => {
+            const rect = this.canvas.getBoundingClientRect();
+            const touch = e.touches[0];
+            this.mouse.x = touch.clientX - rect.left;
+            this.mouse.y = touch.clientY - rect.top;
+        });
+        this.canvas.addEventListener('touchend', e => {
+            this.mouse.left = false;
+        });
     }
 
 

--- a/index.html
+++ b/index.html
@@ -52,6 +52,34 @@
             font-size: 1.2em;
         }
 
+        #mobileControls {
+            position: absolute;
+            bottom: 10px;
+            left: 0;
+            width: 100%;
+            display: none;
+            z-index: 5;
+            padding: 0 20px;
+            box-sizing: border-box;
+            justify-content: space-between;
+            pointer-events: none;
+        }
+        body.mobile-mode #mobileControls { display: flex; }
+        #mobileControls .left-controls, #mobileControls .right-controls {
+            display: flex;
+            gap: 10px;
+        }
+        #mobileControls button {
+            width: 60px;
+            height: 60px;
+            pointer-events: auto;
+            background: rgba(0,0,0,0.5);
+            border: 2px solid var(--primary-color);
+            border-radius: 8px;
+            color: var(--text-light);
+            font-size: 1.2em;
+        }
+
         /* --- NOUVEL ÉCRAN TITRE AMÉLIORÉ --- */
         @keyframes ken-burns {
             0% { transform: scale(1.0) translate(0, 0); }
@@ -400,6 +428,16 @@
 <body>
     <div id="gameWrapper">
         <canvas id="gameCanvas"></canvas>
+        <div id="mobileControls">
+            <div class="left-controls">
+                <button id="btnLeft">◀</button>
+                <button id="btnRight">▶</button>
+            </div>
+            <div class="right-controls">
+                <button id="btnJump">⬆</button>
+                <button id="btnAction">⨀</button>
+            </div>
+        </div>
         
         <div id="titleScreen">
             <div id="art-pane">


### PR DESCRIPTION
## Summary
- provide a mobile control overlay with left/right/jump/action buttons
- hook touch events in the game engine so the buttons trigger movement
- treat finger taps on the canvas like mouse actions
- document the new mobile mode in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a73f508832b9516aa85c1988417