### PR TITLE
Fix camera center and adjust default zoom

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "tileSize": 16,
-  "zoom": 3,
+  "zoom": 2,
   "chunkSize": 16,
   "worldWidth": 3008,
   "worldHeight": 4096,

--- a/game.js
+++ b/game.js
@@ -47,6 +47,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     Object.assign(config, options);
 
     const canvas = document.getElementById('gameCanvas');
+
+    function resizeCanvas() {
+        canvas.width = canvas.clientWidth;
+        canvas.height = canvas.clientHeight;
+    }
+    window.addEventListener('resize', resizeCanvas);
+    resizeCanvas();
+
     const engine = new GameEngine(canvas, config);
 
     const optionsMenu = document.getElementById('optionsMenu');
@@ -105,6 +113,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         mobileModeCheckbox.addEventListener('change', () => {
             config.mobileMode = mobileModeCheckbox.checked;
             document.body.classList.toggle('mobile-mode', config.mobileMode);
+            resizeCanvas();
         });
 
         soundSlider.addEventListener('input', () => {

--- a/options.json
+++ b/options.json
@@ -1,5 +1,5 @@
 {
-  "zoom": 3,
+  "zoom": 2,
   "renderDistance": 8,
   "showParticles": true,
   "weatherEffects": true,


### PR DESCRIPTION
## Summary
- resize the canvas based on the element size
- update default zoom level to 2 in `config.json` and `options.json`
- ensure canvas resizes when mobile mode toggles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d42b9ec18832b935ac1ca73db6d59