### PR TITLE
Reduce player and tool dimensions

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,14 +33,14 @@
   },
   "player": {
     "maxLives": 5,
-    "width": 24,
-    "height": 24,
+    "width": 12,
+    "height": 12,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 3,
-      "offsetY": 3,
-      "width": 18,
-      "height": 18
+      "offsetX": 1.5,
+      "offsetY": 1.5,
+      "width": 9,
+      "height": 9
     },
     "reach": 4,
     "attackRange": 20


### PR DESCRIPTION
## Summary
- Halve player size and adjust hitbox to shrink player and equipped tools

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d955867e4832bb7382668a9b8186e