### PR TITLE
feat: enable infinite world generation

### DIFF
--- a/game.js
+++ b/game.js
@@ -2,7 +2,7 @@
 
 import { GameEngine } from './engine.js';
 import { Player } from './player.js';
-import { TILE, generateLevel } from './world.js';
+import { TILE, generateLevel, ensureWorldColumns } from './world.js';
 import { PNJ } from './PNJ.js';
 import { generatePNJ } from './generateurPNJ.js';
 import { updateMining } from './miningEngine.js';
@@ -209,10 +209,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             game.sound = new SoundManager(config.soundVolume);
             game.logger.log("Génération du monde...");
             generateLevel(game, config);
-            
+
             game.player = new Player(100, 100, config, game.sound);
-            
-            const startXTile = Math.floor(game.tileMap[0].length / 4);
+
+            const startXTile = Math.floor(game.generatedRange.max / 4);
             for (let y = 0; y < game.tileMap.length; y++) {
                 if (game.tileMap[y][startXTile] > TILE.AIR) {
                     game.player.x = startXTile * config.tileSize;
@@ -251,7 +251,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (game.worldAnimator) game.worldAnimator.update(game.camera, canvas, config.zoom);
             if (game.timeSystem) game.timeSystem.update();
             game.logger.update();
-            
+
+            const playerTileX = Math.floor(game.player.x / config.tileSize);
+            const bufferTiles = config.renderDistance * config.chunkSize;
+            ensureWorldColumns(game, config, playerTileX - bufferTiles, playerTileX + bufferTiles);
+
             const { zoom, worldWidth, worldHeight } = config;
             const canvasWidth = canvas.clientWidth;
             const canvasHeight = canvas.clientHeight;
@@ -299,7 +303,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const endY = startY + Math.ceil(canvas.height / zoom / tileSize) + 2;
 
             for (let y = Math.max(0, startY); y < Math.min(game.tileMap.length, endY); y++) {
-                for (let x = Math.max(0, startX); x < Math.min(game.tileMap[0].length, endX); x++) {
+                for (let x = Math.max(0, startX); x < endX; x++) {
                     const tileType = game.tileMap[y][x];
                     if (tileType > TILE.AIR) {
                         const assetKey = Object.keys(TILE).find(key => TILE[key] === tileType);

--- a/world.js
+++ b/world.js
@@ -1,4 +1,3 @@
-import { randomChestType } from './chestGenerator.js';
 import { SeededRandom } from './seededRandom.js';
 import { Perlin } from './perlin.js';
 import { Slime, Frog, Golem } from './enemy.js';
@@ -17,76 +16,95 @@ export const TILE = {
     AMETHYST: 31,
 };
 
-export function generateLevel(game, config) {
-    SeededRandom.setSeed(config.seed || Date.now());
-    Perlin.seed();
-    
-    const { worldWidth, worldHeight, tileSize, generation } = config;
-    const worldWidthInTiles = Math.floor(worldWidth / tileSize);
-    const worldHeightInTiles = Math.floor(worldHeight / tileSize);
-
-    game.tileMap = Array(worldHeightInTiles).fill(0).map(() => Array(worldWidthInTiles).fill(TILE.AIR));
-    
+function generateColumns(game, config, startX, width) {
+    const worldHeightInTiles = game.tileMap.length;
     const surfaceLevel = Math.floor(worldHeightInTiles * 0.4);
+    const { tileSize } = config;
 
-    // 1. Génération du terrain de base
-    for (let x = 0; x < worldWidthInTiles; x++) {
+    for (let x = startX; x < startX + width; x++) {
         const groundY = surfaceLevel + Math.floor(Perlin.get(x * 0.05, 0) * 10);
         for (let y = groundY; y < worldHeightInTiles; y++) {
             if (y === groundY) game.tileMap[y][x] = TILE.GRASS;
             else if (y < groundY + 5) game.tileMap[y][x] = TILE.DIRT;
             else game.tileMap[y][x] = TILE.STONE;
         }
-    }
 
-    // 2. Génération des arbres
-    for (let i = 0; i < (generation.treeCount || 20); i++) {
-        const x = Math.floor(SeededRandom.random() * (worldWidthInTiles - 10)) + 5;
-        for (let y = 10; y < worldHeightInTiles; y++) {
-            if (game.tileMap[y]?.[x] === TILE.GRASS && game.tileMap[y - 1]?.[x] === TILE.AIR) {
-                const treeHeight = 5 + Math.floor(SeededRandom.random() * 5);
-                for (let j = 0; j < treeHeight; j++) {
-                    if (y - 1 - j > 0) game.tileMap[y - 1 - j][x] = TILE.OAK_WOOD;
-                }
-                const leafRadius = 3;
-                const leafCenterY = y - treeHeight;
-                for(let ly = -leafRadius; ly <= leafRadius; ly++) {
-                    for(let lx = -leafRadius; lx <= leafRadius; lx++) {
-                        if(Math.hypot(lx, ly) < leafRadius + 0.5) {
-                            const currentX = x + lx;
-                            const currentY = leafCenterY + ly;
-                            if(game.tileMap[currentY]?.[currentX] === TILE.AIR) {
-                                game.tileMap[currentY][currentX] = TILE.OAK_LEAVES;
+        if (SeededRandom.random() < 0.05) {
+            for (let y = 10; y < worldHeightInTiles; y++) {
+                if (game.tileMap[y]?.[x] === TILE.GRASS && game.tileMap[y - 1]?.[x] === TILE.AIR) {
+                    const treeHeight = 5 + Math.floor(SeededRandom.random() * 5);
+                    for (let j = 0; j < treeHeight; j++) {
+                        if (y - 1 - j > 0) game.tileMap[y - 1 - j][x] = TILE.OAK_WOOD;
+                    }
+                    const leafRadius = 3;
+                    const leafCenterY = y - treeHeight;
+                    for (let ly = -leafRadius; ly <= leafRadius; ly++) {
+                        for (let lx = -leafRadius; lx <= leafRadius; lx++) {
+                            if (Math.hypot(lx, ly) < leafRadius + 0.5) {
+                                const currentX = x + lx;
+                                const currentY = leafCenterY + ly;
+                                if (game.tileMap[currentY]?.[currentX] === TILE.AIR || game.tileMap[currentY]?.[currentX] === undefined) {
+                                    game.tileMap[currentY][currentX] = TILE.OAK_LEAVES;
+                                }
                             }
                         }
                     }
+                    break;
                 }
-                break;
             }
         }
+
+        if (SeededRandom.random() < 0.02) {
+            const enemyTypes = [Slime, Frog, Golem];
+            for (let y = 0; y < worldHeightInTiles; y++) {
+                if (game.tileMap[y]?.[x] > TILE.AIR && game.tileMap[y - 1]?.[x] === TILE.AIR) {
+                    const EnemyType = enemyTypes[Math.floor(SeededRandom.random() * enemyTypes.length)];
+                    game.enemies.push(new EnemyType(x * tileSize, (y - 2) * tileSize, config));
+                    break;
+                }
+            }
+        }
+
+        if (SeededRandom.random() < 0.005) {
+            for (let y = 0; y < worldHeightInTiles; y++) {
+                if (game.tileMap[y]?.[x] > TILE.AIR && game.tileMap[y - 1]?.[x] === TILE.AIR) {
+                    game.pnjs.push(new PNJ(x * tileSize, (y - 2) * tileSize, config, generatePNJ()));
+                    break;
+                }
+            }
+        }
+    }
+}
+
+export function generateLevel(game, config) {
+    SeededRandom.setSeed(config.seed || Date.now());
+    Perlin.seed();
+
+    const { worldWidth = 0, worldHeight, tileSize } = config;
+    const worldHeightInTiles = Math.floor(worldHeight / tileSize);
+
+    game.tileMap = Array(worldHeightInTiles).fill(0).map(() => []);
+    game.generatedRange = { min: 0, max: 0 };
+
+    const initialWidth = Math.floor(worldWidth / tileSize) || 0;
+    generateColumns(game, config, 0, initialWidth);
+    game.generatedRange.max = initialWidth;
+    config.worldWidth = initialWidth * tileSize;
+}
+
+export function ensureWorldColumns(game, config, fromX, toX) {
+    const start = Math.max(0, Math.floor(fromX));
+    const end = Math.max(start, Math.floor(toX));
+
+    if (start < game.generatedRange.min) {
+        generateColumns(game, config, start, game.generatedRange.min - start);
+        game.generatedRange.min = start;
     }
 
-    // 3. Génération des ennemis
-    const enemyTypes = [Slime, Frog, Golem];
-    for (let i = 0; i < (generation.enemyCount || 15); i++) {
-        const x = Math.floor(SeededRandom.random() * worldWidthInTiles);
-        for (let y = 0; y < worldHeightInTiles; y++) {
-            if (game.tileMap[y]?.[x] > TILE.AIR && game.tileMap[y-1]?.[x] === TILE.AIR) {
-                const EnemyType = enemyTypes[Math.floor(SeededRandom.random() * enemyTypes.length)];
-                game.enemies.push(new EnemyType(x * tileSize, (y-2) * tileSize, config));
-                break;
-            }
-        }
+    if (end > game.generatedRange.max) {
+        generateColumns(game, config, game.generatedRange.max, end - game.generatedRange.max);
+        game.generatedRange.max = end;
     }
 
-    // 4. Génération des PNJ
-    for (let i = 0; i < (generation.pnjCount || 5); i++) {
-        const x = Math.floor(worldWidthInTiles / 4 + SeededRandom.random() * (worldWidthInTiles / 2));
-         for (let y = 0; y < worldHeightInTiles; y++) {
-            if (game.tileMap[y]?.[x] > TILE.AIR && game.tileMap[y-1]?.[x] === TILE.AIR) {
-                game.pnjs.push(new PNJ(x * tileSize, (y - 2) * tileSize, config, generatePNJ()));
-                break;
-            }
-        }
-    }
+    config.worldWidth = (game.generatedRange.max - game.generatedRange.min) * config.tileSize;
 }


### PR DESCRIPTION
## Summary
- support dynamically expanding worlds with new column generator
- grow world boundaries as the player explores
- remove fixed map width in renderer to allow unbounded terrain

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d96574170832b9801fcee1350172b