### PR TITLE
Enhance creature generators with patterns and limbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Activez le mode mobile dans le menu Options pour afficher des boutons tactiles (
 ### Nouveautés graphiques
 - Le canvas ajuste maintenant automatiquement sa taille à la fenêtre pour un affichage net.
 - Le héros est plus petit et les outils visibles dans ses mains sont désormais beaucoup plus réduits (environ un vingtième de leur taille d'origine).
+- Les générateurs de monstres et d'animaux ajoutent désormais des motifs (rayures, taches) et des membres pour des créatures plus détaillées.

--- a/generateurAnimaux.js
+++ b/generateurAnimaux.js
@@ -51,6 +51,7 @@ const ANIMAL_PARTS = {
 };
 
 const randomChoice = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const BODY_PATTERNS = ['none', 'stripes', 'spots'];
 
 export function generateAnimal(options = {}) {
     const biome = options.biome || 'surface';
@@ -76,6 +77,7 @@ export function generateAnimal(options = {}) {
     const bodyColor = randomChoice(palette);
     const eyeColor = randomChoice(palette.filter(c => c !== bodyColor));
     let svgParts = [];
+    const pattern = randomChoice(BODY_PATTERNS);
 
     // Assemblage des parties
     if (parts.bodies) svgParts.push(randomChoice(parts.bodies).replace(/{color}/g, bodyColor));
@@ -88,6 +90,13 @@ export function generateAnimal(options = {}) {
     }
     if (parts.extras && Math.random() < 0.5) {
         svgParts.push(randomChoice(parts.extras).replace(/{color}/g, bodyColor).replace(/{eyeColor}/g, eyeColor));
+    }
+
+    // Motifs simples sur le corps
+    if (pattern === 'stripes') {
+        svgParts.push(`<path d="M0 45 H100 M0 55 H100" stroke="${eyeColor}" stroke-width="3" opacity="0.4"/>`);
+    } else if (pattern === 'spots') {
+        svgParts.push(`<circle cx="40" cy="55" r="5" fill="${eyeColor}" opacity="0.4"/><circle cx="60" cy="45" r="4" fill="${eyeColor}" opacity="0.4"/>`);
     }
 
     // Oeil simple pour tous

--- a/generateurMonstres.js
+++ b/generateurMonstres.js
@@ -30,6 +30,8 @@ const MOUTH_SHAPES = [
     { type: 'sharp_teeth', path: 'M35 70 L40 78 L45 70 L50 78 L55 70 L60 78 L65 70' },
 ];
 
+const BODY_PATTERNS = ['none', 'stripes', 'spots'];
+
 const randomChoice = (arr) => arr[Math.floor(Math.random() * arr.length)];
 const randomBetween = (min, max) => Math.floor(Math.random() * (max - min + 1) + min);
 
@@ -61,6 +63,8 @@ export function generateMonster(options = {}) {
         mouthShape: (biome === 'hell' && Math.random() < 0.5) ? MOUTH_SHAPES.find(m => m.type === 'sharp_teeth') : randomChoice(MOUTH_SHAPES),
         hasHorns: Math.random() > 0.3, // Plus de chance d'avoir des cornes
         hasExtraFeature: Math.random() > 0.5, // Pour les ailes, antennes, etc.
+        bodyPattern: randomChoice(BODY_PATTERNS),
+        hasLimbs: Math.random() > 0.6,
     };
     
     properties.eyeColor = randomChoice(palette.filter(c => c !== properties.bodyColor));
@@ -142,11 +146,43 @@ export function generateMonster(options = {}) {
         }
     }
 
+    // 6. Membres basiques
+    let limbsSvg = '';
+    if (properties.hasLimbs) {
+        const legY = body.y + body.height;
+        limbsSvg = `
+            <rect x="${body.x + 5}" y="${legY}" width="10" height="20" fill="${properties.bodyColor}" stroke="#1E1E1E" stroke-width="2"/>
+            <rect x="${body.x + body.width - 15}" y="${legY}" width="10" height="20" fill="${properties.bodyColor}" stroke="#1E1E1E" stroke-width="2"/>
+        `;
+    }
+
+    // 7. Motifs sur le corps
+    let patternSvg = '';
+    if (properties.bodyPattern === 'stripes') {
+        const stripeY1 = body.y + body.height * 0.3;
+        const stripeY2 = body.y + body.height * 0.6;
+        patternSvg = `
+            <path d="M ${body.x} ${stripeY1} H ${body.x + body.width}" stroke="${properties.eyeColor}" stroke-width="4" opacity="0.5"/>
+            <path d="M ${body.x} ${stripeY2} H ${body.x + body.width}" stroke="${properties.eyeColor}" stroke-width="4" opacity="0.5"/>
+        `;
+    } else if (properties.bodyPattern === 'spots') {
+        const spot1x = body.x + body.width * 0.3;
+        const spot1y = body.y + body.height * 0.4;
+        const spot2x = body.x + body.width * 0.7;
+        const spot2y = body.y + body.height * 0.7;
+        patternSvg = `
+            <circle cx="${spot1x}" cy="${spot1y}" r="6" fill="${properties.eyeColor}" opacity="0.5"/>
+            <circle cx="${spot2x}" cy="${spot2y}" r="5" fill="${properties.eyeColor}" opacity="0.5"/>
+        `;
+    }
+
     // Assemblage final du SVG
     const svgString = `<svg viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg">
         ${hornsSvg}
         ${extraFeatureSvg}
         ${bodySvg}
+        ${patternSvg}
+        ${limbsSvg}
         ${eyesSvg}
         ${mouthSvg}
     </svg>`;


### PR DESCRIPTION
## Summary
- Add optional limbs and body patterns to monster sprites
- Allow animals to spawn with stripe or spot patterns
- Document the richer creature generators in README

## Testing
- `node -e "import('./generateurMonstres.js').then(m=>console.log(m.generateMonster({biome:'surface'})))"`
- `node -e "import('./generateurAnimaux.js').then(m=>console.log(m.generateAnimal({biome:'surface'})))"`


------
https://chatgpt.com/codex/tasks/task_e_688d98a42b9c832b9e8af7617c8fc8a1