### PR TITLE
Load player assets by default

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -28,10 +28,14 @@ export class GameEngine {
         }
 
         for (const key of allAssetKeys) {
-            const path = this.config.assets[key];
+            let path = this.config.assets[key];
+
+            // If the asset is referenced (e.g. in an animation) but not
+            // explicitly listed in the config, fall back to the conventional
+            // "assets/<key>.png" path so that all player frames and tools can
+            // still be loaded.
             if (!path) {
-                console.warn(`Chemin manquant pour l'asset '${key}' dans config.json`);
-                continue;
+                path = `assets/${key}.png`;
             }
 
             promises.push(new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Ensure `loadAssets` falls back to `assets/<key>.png` so every referenced player animation frame is loaded

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d9bf13534832b9c7f977594176f51