### PR TITLE
Fix mining tools not responding to keyboard actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Interface enrichie :
 
 ## Cassage de blocs
 
-Le module `miningEngine.js` gère la destruction des tuiles. Maintenez l'action sur un bloc pour remplir la jauge de minage. Une fois pleine, le bloc se transforme en objet collectable qui rejoint l'inventaire au contact du joueur (`player.inventory`). Intégrez simplement le moteur en appelant `updateMining(game, keys, mouse)` à chaque frame.
+Le module `miningEngine.js` gère la destruction des tuiles. Maintenez l'action sur un bloc pour remplir la jauge de minage. Une fois pleine, le bloc se transforme en objet collectable qui rejoint l'inventaire au contact du joueur (`player.inventory`). Intégrez simplement le moteur en appelant `updateMining(game, keys, mouse, delta)` à chaque frame.
 
 ### Outils disponibles
 
@@ -49,7 +49,7 @@ Les outils utilisables pour casser les blocs disposent chacun de leur icône dan
 
 ### Utilisation des outils
 
-Appuyez sur **A** ou cliquez avec la souris pour utiliser l'outil sélectionné. Vous pouvez miner les blocs, mais aussi infliger des dégâts aux ennemis à portée. Utilisez la molette ou les touches **1-9** pour changer rapidement d'outil.
+Appuyez sur la touche d'action (**E** par défaut) ou cliquez avec le bouton gauche de la souris pour utiliser l'outil sélectionné. Vous pouvez miner les blocs, mais aussi infliger des dégâts aux ennemis à portée. Utilisez la molette ou les touches **1-9** pour changer rapidement d'outil.
 
 ### Physique des blocs
 

--- a/game.js
+++ b/game.js
@@ -246,7 +246,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             });
 
-            updateMining(game, mouse, delta);
+            // Passe également les touches clavier pour permettre le minage via la touche d'action
+            updateMining(game, keys, mouse, delta);
             game.particleSystem.update();
             if (game.worldAnimator) game.worldAnimator.update(game.camera, canvas, config.zoom);
             if (game.timeSystem) game.timeSystem.update();

--- a/miningEngine.js
+++ b/miningEngine.js
@@ -11,9 +11,10 @@ const TOOL_EFFICIENCY = {
     axe:    { [TILE.WOOD]: 3, [TILE.LEAVES]: 3, [TILE.OAK_WOOD]: 3, [TILE.OAK_LEAVES]: 3 },
 };
 
-export function updateMining(game, mouse, delta) {
+// Ajout de "keys" pour permettre l'utilisation de la touche d'action
+export function updateMining(game, keys, mouse, delta) {
     const player = game.player;
-    if (!player || !mouse.left || !player.miningTarget) {
+    if (!player || !(mouse.left || keys?.action) || !player.miningTarget) {
         if (player) player.miningProgress = 0;
         game.miningEffect = null;
         return;


### PR DESCRIPTION
## Summary
- allow mining with the action key in addition to mouse click
- document action key and updated mining engine call

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d9cc3c5e8832bbcb648286a6d9d67