### PR TITLE
Increase default player size

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,14 +33,14 @@
   },
   "player": {
     "maxLives": 5,
-    "width": 24,
-    "height": 24,
+    "width": 32,
+    "height": 32,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 3,
-      "offsetY": 3,
-      "width": 18,
-      "height": 18
+      "offsetX": 4,
+      "offsetY": 4,
+      "width": 24,
+      "height": 24
     },
     "reach": 4,
     "attackRange": 20

--- a/game.js
+++ b/game.js
@@ -20,7 +20,7 @@ async function loadConfig() {
         return await resp.json();
     } catch (e) {
         console.error("Impossible de charger config.json. Utilisation d'une configuration par défaut.", e);
-        return {"tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":24,"height":24,"hitbox":{"offsetX":3,"offsetY":3,"width":18,"height":21}}};
+        return {"tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":32,"height":32,"hitbox":{"offsetX":4,"offsetY":4,"width":24,"height":24}}};
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge default player dimensions and hitbox for better visibility
- adjust fallback configuration accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d9f450dc0832bbf0e5964d067b18c