### PR TITLE
Fix tree generation when adjacent tile is undefined

### DIFF
--- a/world.js
+++ b/world.js
@@ -44,7 +44,10 @@ function generateColumns(game, config, startX, width) {
 
         if (SeededRandom.random() < 0.05) {
             for (let y = 10; y < worldHeightInTiles; y++) {
-                if (game.tileMap[y]?.[x] === TILE.GRASS && game.tileMap[y - 1]?.[x] === TILE.AIR) {
+                if (
+                    game.tileMap[y]?.[x] === TILE.GRASS &&
+                    (game.tileMap[y - 1]?.[x] === TILE.AIR || game.tileMap[y - 1]?.[x] === undefined)
+                ) {
                     const treeHeight = 5 + Math.floor(SeededRandom.random() * 5);
                     for (let j = 0; j < treeHeight; j++) {
                         if (y - 1 - j > 0) game.tileMap[y - 1 - j][x] = TILE.OAK_WOOD;


### PR DESCRIPTION
## Summary
- Allow tree placement even when the block above ground hasn't been initialized

## Testing
- `node --input-type=module -e "import('./world.js').then(({generateLevel, TILE})=>{const game={tileMap:[],enemies:[],pnjs:[]}; const config={worldWidth:3008, worldHeight:4096, tileSize:16, seed:123, generation:{}}; generateLevel(game, config); let count=0; for (const row of game.tileMap) for (const cell of row) if(cell===TILE.OAK_WOOD) count++; console.log('trees:',count);}).catch(e=>console.error(e));"`

------
https://chatgpt.com/codex/tasks/task_e_688da1843048832b8d560d3bdfcbec99