### PR TITLE
Double player size

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,14 +33,14 @@
   },
   "player": {
     "maxLives": 5,
-    "width": 32,
-    "height": 32,
+    "width": 64,
+    "height": 64,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 4,
-      "offsetY": 4,
-      "width": 24,
-      "height": 24
+      "offsetX": 8,
+      "offsetY": 8,
+      "width": 48,
+      "height": 48
     },
     "reach": 4,
     "attackRange": 20

--- a/game.js
+++ b/game.js
@@ -20,7 +20,7 @@ async function loadConfig() {
         return await resp.json();
     } catch (e) {
         console.error("Impossible de charger config.json. Utilisation d'une configuration par défaut.", e);
-        return {"tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":32,"height":32,"hitbox":{"offsetX":4,"offsetY":4,"width":24,"height":24}}};
+        return {"tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":64,"height":64,"hitbox":{"offsetX":8,"offsetY":8,"width":48,"height":48}}};
     }
 }
 


### PR DESCRIPTION
## Summary
- double player dimensions and hitbox to 64x64
- update default config fallback to match new size

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688dadac3a08832ba09c88c4b839e123