### PR TITLE
fix: ensure canvas fills viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,15 +30,15 @@
         
         #gameWrapper {
             position: relative;
-            width: 100%;
-            height: 100%;
+            width: 100vw;
+            height: 100vh;
             z-index: 2;
             background: #000;
         }
         #gameCanvas {
             display: block;
-            width: 100%;
-            height: 100%;
+            width: 100vw;
+            height: 100vh;
             background: transparent;
             image-rendering: -webkit-optimize-contrast;
             image-rendering: -moz-crisp-edges;
@@ -637,8 +637,10 @@
             const hud = document.getElementById('hud');
 
             function resizeCanvas() {
-                canvas.width = canvas.clientWidth;
-                canvas.height = canvas.clientHeight;
+                canvas.width = window.innerWidth;
+                canvas.height = window.innerHeight;
+                canvas.style.width = `${window.innerWidth}px`;
+                canvas.style.height = `${window.innerHeight}px`;
             }
             window.addEventListener('resize', resizeCanvas);
             resizeCanvas();


### PR DESCRIPTION
## Summary
- size canvas and wrapper with viewport units to prevent zero dimensions
- synchronize canvas dimensions with window size on resize

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688dc1d42a54832b87ae1834855092f6