### PR TITLE
feat: show game version in title

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.01",
   "tileSize": 16,
   "zoom": 2,
   "chunkSize": 16,

--- a/game.js
+++ b/game.js
@@ -20,7 +20,7 @@ async function loadConfig() {
         return await resp.json();
     } catch (e) {
         console.error("Impossible de charger config.json. Utilisation d'une configuration par défaut.", e);
-        return {"tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":64,"height":64,"hitbox":{"offsetX":8,"offsetY":8,"width":48,"height":48}}};
+        return {"version":"0.01","tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":64,"height":64,"hitbox":{"offsetX":8,"offsetY":8,"width":48,"height":48}}};
     }
 }
 
@@ -43,6 +43,7 @@ function saveOptions(opts) {
 
 document.addEventListener('DOMContentLoaded', async () => {
     const config = await loadConfig();
+    document.title = `Super Pixel Adventure 2 V.${config.version || '0.01'}`;
     const options = await loadOptions();
     Object.assign(config, options);
 

--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@
                 return await resp.json();
             } catch (e) {
                 console.error("Impossible de charger config.json. Utilisation d'une configuration par défaut.", e);
-                return {"tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":32,"height":32,"hitbox":{"offsetX":4,"offsetY":4,"width":24,"height":24}}};
+                return {"version":"0.01","tileSize":16,"zoom":3,"worldWidth":2048,"worldHeight":1024,"generation":{"enemyCount":10,"treeCount":20},"physics":{"gravity":0.35,"jumpForce":8,"playerSpeed":3,"friction":0.85,"airResistance":0.98,"maxFallSpeed":10,"groundAcceleration":0.4,"airAcceleration":0.2},"player":{"width":32,"height":32,"hitbox":{"offsetX":4,"offsetY":4,"width":24,"height":24}}};
             }
         }
 
@@ -628,6 +628,7 @@
             console.log("Événement 'start-game' reçu avec la seed:", seed);
 
             const config = await loadConfig();
+            document.title = `Super Pixel Adventure 2 V.${config.version || '0.01'}`;
             const options = await loadOptions();
             Object.assign(config, options);
             config.seed = seed;


### PR DESCRIPTION
## Summary
- display game version from config.json in the document title
- default configs now include a version field

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688dcad5fb98832bb79e9dfa4617d03d