### PR TITLE
Initialize effects before calculating derived stats

### DIFF
--- a/combatSystem.js
+++ b/combatSystem.js
@@ -15,16 +15,16 @@ export class PlayerStats {
         this.mining = 10;
         this.luck = 5;
         
+        // Effets temporaires
+        this.effects = new Map();
+
+        // Équipement (initialisé vide)
+        this.equipment = new Map();
+
         // Statistiques dérivées
         this.attackDamage = this.calculateAttackDamage();
         this.moveSpeed = this.calculateMoveSpeed();
         this.miningSpeed = this.calculateMiningSpeed();
-        
-        // Effets temporaires
-        this.effects = new Map();
-        
-        // Équipement (initialisé vide)
-        this.equipment = new Map();
         
         // Statistiques de jeu
         this.blocksMinedTotal = 0;


### PR DESCRIPTION
## Summary
- Ensure PlayerStats initializes effects and equipment before computing derived stats

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e7cf8efd0832b8771031d647d542e