### PR TITLE
fix: guard player stat effects

### DIFF
--- a/combatSystem.js
+++ b/combatSystem.js
@@ -131,8 +131,8 @@ export class PlayerStats {
     calculateAttackDamage() {
         let damage = this.strength;
         
-        // Appliquer les effets
-        for (const effect of this.effects.values()) {
+        // Appliquer les effets si disponibles
+        for (const effect of this.effects?.values?.() || []) {
             if (effect && effect.modifier && effect.modifier.attackDamage) {
                 damage += effect.modifier.attackDamage;
             }
@@ -143,8 +143,8 @@ export class PlayerStats {
 
     calculateMoveSpeed() {
         let speed = this.speed;
-        
-        for (const effect of this.effects.values()) {
+
+        for (const effect of this.effects?.values?.() || []) {
             if (effect && effect.modifier && effect.modifier.speed) {
                 speed += effect.modifier.speed;
             }
@@ -155,8 +155,8 @@ export class PlayerStats {
 
     calculateMiningSpeed() {
         let mining = this.mining;
-        
-        for (const effect of this.effects.values()) {
+
+        for (const effect of this.effects?.values?.() || []) {
             if (effect && effect.modifier && effect.modifier.mining) {
                 mining += effect.modifier.mining;
             }


### PR DESCRIPTION
## Summary
- handle missing player effects during attack, movement, and mining stat calculations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e7e07fa88832bb7092ac3aa47d90a