### PR TITLE
fix: respect pause state in game loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1932,20 +1932,22 @@
                         }
                         
                         try {
-                            // Mettre à jour la logique
-                            logic.update(delta, getKeys(), getMouse());
-                            
-                            // Dessiner
+                            // Mettre à jour la logique uniquement si le jeu n'est pas en pause
+                            if (!logic.isPaused || !logic.isPaused()) {
+                                logic.update(delta, getKeys(), getMouse());
+                            }
+
+                            // Dessiner (toujours afficher, même en pause)
                             const ctx = canvas.getContext('2d');
                             ctx.clearRect(0, 0, canvas.width, canvas.height);
-                            
+
                             // Le jeu est maintenant actif
-                            
+
                             logic.draw(ctx, game.assets || {});
                         } catch (error) {
                             console.error("Erreur dans la boucle de jeu:", error);
                         }
-                        
+
                         requestAnimationFrame(gameLoop);
                     };
                     


### PR DESCRIPTION
## Summary
- avoid updating game logic when paused
- keep rendering while paused

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e847401c4832b94760539658b1483