### PR TITLE
fix: allow async imports during game init

### DIFF
--- a/index.html
+++ b/index.html
@@ -1168,7 +1168,7 @@
             window.closeOptionsMenu = closeOptionsMenu;
 
             const gameLogic = {
-                init(assets = {}) {
+                async init(assets = {}) {
                     console.log("Initialisation du jeu...");
                     game.assets = assets;
                     


### PR DESCRIPTION
## Summary
- make `gameLogic.init` asynchronous so `await import` works during setup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f73230124832ba64e4f8848866d29