### PR TITLE
fix: remove duplicate WorldIntegrationSystem export

### DIFF
--- a/worldIntegrationSystem.js
+++ b/worldIntegrationSystem.js
@@ -971,4 +971,3 @@ export class WorldIntegrationSystem {
     }
 }
 
-export { WorldIntegrationSystem };


### PR DESCRIPTION
## Summary
- remove redundant `export { WorldIntegrationSystem }` statement

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f749ddca8832bae4656dacebc8a97