### PR TITLE
fix: remove duplicate WorldIntegrationSystem export

### DIFF
--- a/gameIntegration.js
+++ b/gameIntegration.js
@@ -1,5 +1,5 @@
 // gameIntegration.js - Intégration du monde complexe dans le jeu existant
-import { WorldIntegrationSystem } from './worldIntegrationSystem.js';
+import WorldIntegrationSystem from './worldIntegrationSystem.js';
 
 // Fonction principale d'intégration
 export function integrateComplexWorld(game, config, gameLogic) {

--- a/worldIntegrationSystem.js
+++ b/worldIntegrationSystem.js
@@ -4,7 +4,7 @@ import { AdvancedBiomeSystem } from './advancedBiomeSystem.js';
 import { ExplorationSystem } from './explorationSystem.js';
 import { TILE } from './world.js';
 
-export class WorldIntegrationSystem {
+export default class WorldIntegrationSystem {
     constructor(config) {
         this.config = config;
         this.complexWorldSystem = new ComplexWorldSystem(config);


### PR DESCRIPTION
## Summary
- avoid duplicate WorldIntegrationSystem exports by using a default export
- update gameIntegration to import the default

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f76c9e2b8832ba35f022c17527674