### PR TITLE
fix: remove duplicate AdvancedBiomeSystem export

### DIFF
--- a/advancedBiomeSystem.js
+++ b/advancedBiomeSystem.js
@@ -1064,5 +1064,3 @@ export class AdvancedBiomeSystem {
         return this.animalDistribution[biome] || { common: [], uncommon: [], rare: [], legendary: [] };
     }
 }
-
-export { AdvancedBiomeSystem };


### PR DESCRIPTION
## Summary
- remove duplicate export in `advancedBiomeSystem.js` causing SyntaxError

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f783e46a4832bac3833a8e1bbaa3b