### PR TITLE
fix: avoid canyonNoise redeclaration

### DIFF
--- a/world.js
+++ b/world.js
@@ -134,7 +134,7 @@ function generateColumns(game, config, startX, width) {
         const magic = magicNoise + Math.sin(x * 0.001) * 0.3;
         
         // Détection de formations géologiques spéciales
-        const canyonNoise = Math.abs(Perlin.get(x * 0.007, worldSeed + 500));
+        // canyonNoise is already calculated earlier for terrain generation
         const riverNoise = Math.abs(Perlin.get(x * 0.025, worldSeed + 1000));
         const caveNoise = Perlin.get(x * 0.04, worldSeed + 1500);
         const crystalNoise = Perlin.get(x * 0.03, worldSeed + 2000);


### PR DESCRIPTION
## Summary
- prevent duplicate `canyonNoise` constant definition in world generation

## Testing
- `node world.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f7a962658832b8c16a74109da309f