### PR TITLE
Remove duplicate export in exploration system

### DIFF
--- a/explorationSystem.js
+++ b/explorationSystem.js
@@ -1119,5 +1119,3 @@ export class ExplorationSystem {
         return Array.from(this.secrets.values()).filter(s => s.discovered);
     }
 }
-
-export { ExplorationSystem };


### PR DESCRIPTION
## Summary
- fix syntax error by removing duplicate `ExplorationSystem` export

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check explorationSystem.js`

------
https://chatgpt.com/codex/tasks/task_e_688f7d377fb4832ba965a8133f011731