### PR TITLE
fix: resolve duplicate export error in exploration system

### DIFF
--- a/explorationSystem.js
+++ b/explorationSystem.js
@@ -2,7 +2,7 @@
 import { TILE } from './world.js';
 import { SeededRandom } from './seededRandom.js';
 
-export class ExplorationSystem {
+class ExplorationSystem {
     constructor(config) {
         this.config = config;
         this.discoveredAreas = new Map();
@@ -1119,3 +1119,5 @@ export class ExplorationSystem {
         return Array.from(this.secrets.values()).filter(s => s.discovered);
     }
 }
+
+export default ExplorationSystem;

--- a/worldIntegrationSystem.js
+++ b/worldIntegrationSystem.js
@@ -1,7 +1,7 @@
 // worldIntegrationSystem.js - Système d'intégration du monde complexe
 import { ComplexWorldSystem } from './worldComplexSystem.js';
 import { AdvancedBiomeSystem } from './advancedBiomeSystem.js';
-import { ExplorationSystem } from './explorationSystem.js';
+import ExplorationSystem from './explorationSystem.js';
 import { TILE } from './world.js';
 
 export default class WorldIntegrationSystem {


### PR DESCRIPTION
## Summary
- refactor exploration system to use a default export
- update world integration system to import exploration system via default export

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f7f5779fc832ba5561b88cc564b94