### PR TITLE
Fix world generation bounds for water and terrain

### DIFF
--- a/world.js
+++ b/world.js
@@ -403,8 +403,9 @@ function generateColumns(game, config, startX, width) {
         // Océans et lacs
         if (biome === 'ocean' || (groundY < surfaceLevel - 5)) {
             const waterMaxY = Math.min(worldHeightInTiles, Math.max(surfaceLevel, groundY + 10));
-            for (let y = groundY + 1; y < waterMaxY; y++) {
-                if (game.tileMap[y][x] === TILE.AIR) {
+            const startY = Math.max(0, groundY + 1);
+            for (let y = startY; y < waterMaxY; y++) {
+                if (game.tileMap[y] && game.tileMap[y][x] === TILE.AIR) {
                     game.tileMap[y][x] = TILE.WATER;
                 }
             }
@@ -413,9 +414,11 @@ function generateColumns(game, config, startX, width) {
         // Rivières
         if (isRiver && biome !== 'desert') {
             const riverDepth = 3;
-            for (let y = groundY - riverDepth; y <= groundY; y++) {
-                if (y >= 0 && y < worldHeightInTiles) {
-                    game.tileMap[y][x] = y === groundY - riverDepth ? TILE.WATER : TILE.AIR;
+            const startY = Math.max(0, groundY - riverDepth);
+            const endY = Math.min(worldHeightInTiles - 1, groundY);
+            for (let y = startY; y <= endY; y++) {
+                if (game.tileMap[y]) {
+                    game.tileMap[y][x] = y === startY ? TILE.WATER : TILE.AIR;
                 }
             }
         }
@@ -423,8 +426,10 @@ function generateColumns(game, config, startX, width) {
         // Canyons
         if (isCanyon) {
             const canyonDepth = 15 + Math.floor(SeededRandom.random() * 10);
-            for (let y = groundY - canyonDepth; y < groundY; y++) {
-                if (y >= 0) {
+            const startY = Math.max(0, groundY - canyonDepth);
+            const endY = Math.min(worldHeightInTiles - 1, groundY - 1);
+            for (let y = startY; y <= endY; y++) {
+                if (game.tileMap[y]) {
                     game.tileMap[y][x] = TILE.AIR;
                 }
             }


### PR DESCRIPTION
## Summary
- Clamp water, river, and canyon generation loops to valid world bounds
- Prevent undefined tile access during world generation

## Testing
- `npm test` *(fails: missing script)*
- `node --input-type=module -e "global.Image=class{constructor(){this.complete=true;} set src(v){this._src=v;} get src(){return this._src;}};import('./world.js').then(m=>{const config={tileSize:16,worldWidth:3008,worldHeight:4096,player:{width:64,height:64},physics:{gravity:0.35}};const game={pnjs:[]};m.generateLevel(game,config);console.log('tileMap',game.tileMap.length,game.tileMap[0].length,game.pnjs.length);}).catch(e=>console.error(e));"`


------
https://chatgpt.com/codex/tasks/task_e_688f82b623cc832b9d4be31b34f9bdd5