### PR TITLE
Pass delta time to draw methods

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -144,7 +144,9 @@ export class GameEngine {
                         // CORRECTION : Passe maintenant delta, keys, et mouse à la logique de jeu.
                         this.gameLogic.update(delta, this.keys, this.mouse);
                     }
-                    this.gameLogic.draw(this.ctx, this.assets);
+                    // Passe également delta au rendu afin que la logique de dessin
+                    // puisse effectuer des animations dépendantes du temps.
+                    this.gameLogic.draw(this.ctx, this.assets, delta);
                     requestAnimationFrame(loop);
                 };
                 requestAnimationFrame(loop);

--- a/game.js
+++ b/game.js
@@ -329,7 +329,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         },
 
-        draw(ctx, assets) {
+        // Accepte maintenant delta pour la compatibilité avec le moteur.
+        draw(ctx, assets, delta) {
             if (!game.timeSystem || !game.tileMap.length) return;
 
             const { tileSize, zoom } = config;

--- a/gameIntegration.js
+++ b/gameIntegration.js
@@ -31,10 +31,11 @@ export function integrateComplexWorld(game, config, gameLogic) {
         // Intégrer dans le rendu du jeu
         if (gameLogic && gameLogic.draw) {
             const originalDraw = gameLogic.draw;
-            gameLogic.draw = function(ctx, assets) {
+            // Prend désormais delta en troisième paramètre pour les animations.
+            gameLogic.draw = function(ctx, assets, delta) {
                 // Appeler le rendu original
-                originalDraw.call(this, ctx, assets);
-                
+                originalDraw.call(this, ctx, assets, delta);
+
                 // Rendu des éléments du monde complexe
                 try {
                     drawComplexWorldElements(ctx, game, assets);

--- a/index.html
+++ b/index.html
@@ -1816,7 +1816,8 @@
                     }
                 },
 
-                draw(ctx, assets) {
+                // Passe désormais delta comme troisième argument pour les animations.
+                draw(ctx, assets, delta) {
                     try {
                         // Arrière-plan simple
                         ctx.fillStyle = '#87CEEB';


### PR DESCRIPTION
## Summary
- Pass delta time to game logic draw cycle so animations have access to frame timing
- Forward delta parameter through integration layer and engine loop
- Update game scripts to accept delta in draw methods

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f8cccc5a0832b9bf22fe863f0e9ce