### PR TITLE
Prevent draw-time delta errors

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -144,7 +144,7 @@ export class GameEngine {
                         // CORRECTION : Passe maintenant delta, keys, et mouse à la logique de jeu.
                         this.gameLogic.update(delta, this.keys, this.mouse);
                     }
-                    this.gameLogic.draw(this.ctx, this.assets);
+                    this.gameLogic.draw(this.ctx, this.assets, delta);
                     requestAnimationFrame(loop);
                 };
                 requestAnimationFrame(loop);

--- a/gameIntegration.js
+++ b/gameIntegration.js
@@ -31,10 +31,10 @@ export function integrateComplexWorld(game, config, gameLogic) {
         // Intégrer dans le rendu du jeu
         if (gameLogic && gameLogic.draw) {
             const originalDraw = gameLogic.draw;
-            gameLogic.draw = function(ctx, assets) {
+            gameLogic.draw = function(ctx, assets, delta) {
                 // Appeler le rendu original
-                originalDraw.call(this, ctx, assets);
-                
+                originalDraw.call(this, ctx, assets, delta);
+
                 // Rendu des éléments du monde complexe
                 try {
                     drawComplexWorldElements(ctx, game, assets);

--- a/index.html
+++ b/index.html
@@ -1816,7 +1816,7 @@
                     }
                 },
 
-                draw(ctx, assets) {
+                draw(ctx, assets, delta) {
                     try {
                         // Arrière-plan simple
                         ctx.fillStyle = '#87CEEB';
@@ -2518,7 +2518,7 @@
 
                             // Le jeu est maintenant actif
 
-                            logic.draw(ctx, game.assets || {});
+                            logic.draw(ctx, game.assets || {}, delta);
                         } catch (error) {
                             console.error("Erreur dans la boucle de jeu:", error);
                         }


### PR DESCRIPTION
## Summary
- Pass `delta` to the game's `draw` method to avoid ReferenceError
- Forward delta through integration layer and engine loop

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f8d30a91c832ba859f3c76b1aef7e