### PR TITLE
fix: remove delta usage in draw

### DIFF
--- a/index.html
+++ b/index.html
@@ -2215,11 +2215,10 @@
                             }
                         }
 
-                        // Mettre à jour et dessiner les nouveaux systèmes
+                        // Dessiner les nouveaux systèmes
                         if (game.animalManager) {
-                            game.animalManager.update(game, delta);
                             game.animalManager.draw(ctx, assets);
-                            
+
                             // Spawn des animaux périodiquement
                             if (Math.random() < 0.001) {
                                 const animalTypes = ['cow', 'pig', 'chicken', 'sheep', 'rabbit'];
@@ -2228,27 +2227,26 @@
                             }
                         }
                         if (game.foodSystem) {
-                            game.foodSystem.update(game, delta);
                             game.foodSystem.draw(ctx, assets, game);
                         }
-                        
+
                         // Mettre à jour le système d'ennemis
                         if (game.enemySpawner) {
-                            game.enemySpawner.update(game, delta);
+                            game.enemySpawner.draw && game.enemySpawner.draw(ctx, game, assets);
                         }
-                        
-                        // Mettre à jour les PNJ
+
+                        // Dessiner les PNJ
                         if (game.pnjs) {
                             game.pnjs.forEach(pnj => {
-                                if (pnj.update) {
-                                    pnj.update(game, delta);
+                                if (pnj.draw) {
+                                    pnj.draw(ctx, assets, game);
                                 }
                             });
                         }
-                        
-                        // Mettre à jour le système de quêtes
-                        if (game.questSystem) {
-                            game.questSystem.update(game, delta);
+
+                        // Dessiner les quêtes si nécessaire
+                        if (game.questSystem && game.questSystem.draw) {
+                            game.questSystem.draw(ctx, game);
                         }
                     
                     // Dessiner les projectiles


### PR DESCRIPTION
## Summary
- avoid ReferenceError by removing `delta`-based updates from draw step
- draw systems independently of update loop

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f8d4053f8832b82eeb3cf5bd839d1