### PR TITLE
Fix disaster manager initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1447,7 +1447,9 @@
                     // Initialiser le système de désastres
                     try {
                         const { DisasterManager } = await import('./disasterManager.js');
-                        game.disasterManager = new DisasterManager(config);
+                        // Passer l'objet de jeu pour que le gestionnaire de désastres
+                        // puisse accéder à la caméra et aux autres propriétés nécessaires
+                        game.disasterManager = new DisasterManager(game);
                         console.log('✅ Système de désastres initialisé');
                     } catch (error) {
                         console.warn('⚠️ Erreur lors de l\'initialisation des désastres:', error);

--- a/test-complex-world.html
+++ b/test-complex-world.html
@@ -224,7 +224,9 @@
                 log('Système d\'ennemis initialisé', 'success');
                 
                 const { DisasterManager } = await import('./disasterManager.js');
-                game.disasterManager = new DisasterManager(config);
+                // Fournir l'objet de jeu pour que le gestionnaire de désastres
+                // puisse utiliser la caméra et les autres données du jeu
+                game.disasterManager = new DisasterManager(game);
                 log('Système de désastres initialisé', 'success');
                 
                 const { AdvancedBiomeSystem } = await import('./advancedBiomeSystem.js');


### PR DESCRIPTION
## Summary
- Ensure DisasterManager is created with the game object so it can access camera data
- Update disaster system setup in demo world to use the correct game instance

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f8fd7dd18832ba0b2c6799000fd8a