### PR TITLE
Restrict mining to appropriate tools

### DIFF
--- a/miningEngine.js
+++ b/miningEngine.js
@@ -133,8 +133,18 @@ export function updateMining(game, keys, mouse, delta) {
 
     const toolName = player.tools[player.selectedToolIndex] || 'hand';
     const breakTime = BLOCK_BREAK_TIME[currentType] || 1;
-    const efficiency = TOOL_EFFICIENCY[toolName]?.[currentType] || 0.5;
 
+    // Vérifier si l'outil actuel peut miner ce type de bloc. S'il n'y a
+    // aucune efficacité définie pour cet outil sur ce bloc, cela signifie
+    // que l'outil n'est pas adapté et ne devrait pas permettre le minage.
+    const toolEfficiency = TOOL_EFFICIENCY[toolName]?.[currentType];
+    if (toolName !== 'hand' && toolEfficiency === undefined) {
+        player.miningProgress = 0;
+        game.miningEffect = null;
+        return; // Outil inadapté : pas de progression de minage
+    }
+
+    const efficiency = toolEfficiency ?? 0.5; // 0.5 = main nue
     const timeToBreak = breakTime / efficiency;
     player.miningProgress += delta / timeToBreak;
     game.miningEffect = { x: target.x, y: target.y, progress: player.miningProgress };

--- a/test-mining.js
+++ b/test-mining.js
@@ -1,0 +1,37 @@
+import { updateMining } from './miningEngine.js';
+import { TILE } from './world.js';
+
+// Minimal mock game and player setup
+const mockGame = {
+    config: { tileSize: 16 },
+    tileMap: [[TILE.STONE]],
+    player: {
+        tools: ['pickaxe', 'bow'],
+        selectedToolIndex: 0,
+        miningTarget: { x: 0, y: 0, type: TILE.STONE },
+        miningProgress: 0
+    },
+    miningEffect: null
+};
+
+const mouse = { left: true };
+const keys = {};
+
+// Test with a pickaxe - progress should increase
+updateMining(mockGame, keys, mouse, 0.1);
+if (mockGame.player.miningProgress <= 0) {
+    console.error('❌ Pickaxe did not increase mining progress');
+    process.exit(1);
+}
+
+// Reset and test with a non-mining tool (bow) - progress should stay at 0
+mockGame.player.selectedToolIndex = 1; // bow
+mockGame.player.miningTarget = { x: 0, y: 0, type: TILE.STONE };
+mockGame.player.miningProgress = 0;
+updateMining(mockGame, keys, mouse, 0.1);
+if (mockGame.player.miningProgress !== 0) {
+    console.error('❌ Non-mining tool should not progress mining');
+    process.exit(1);
+}
+
+console.log('✅ All mining tests passed');


### PR DESCRIPTION
## Summary
- prevent non-mining tools from contributing to block destruction
- add unit test covering tool-based mining restrictions

## Testing
- `node test-mining.js`
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_688f94db683c832b971f080de2472e2a