### PR TITLE
feat: add separators between documentation sections

### DIFF
--- a/MONDE_COMPLEXE_README.md
+++ b/MONDE_COMPLEXE_README.md
@@ -6,6 +6,8 @@ Le système de monde complexe transforme le jeu 2D pixel adventure en un univers
 
 ## 🏗️ Architecture du Système
 
+---
+
 ### Fichiers Principaux
 
 1. **[`worldComplexSystem.js`](worldComplexSystem.js)** - Système de destruction environnementale
@@ -16,6 +18,8 @@ Le système de monde complexe transforme le jeu 2D pixel adventure en un univers
 6. **[`test-standalone.html`](test-standalone.html)** - Test autonome et démonstration
 
 ## 🌟 Fonctionnalités Principales
+
+---
 
 ### 🌍 12 Biomes Uniques (Paradis → Enfer)
 
@@ -34,7 +38,11 @@ Le système de monde complexe transforme le jeu 2D pixel adventure en un univers
 | **Infernal Depths** | 85°C | 20% | 6/6 | Enfers ardents, démons |
 | **Abyssal Depths** | 2°C | 95% | 6/6 | Profondeurs océaniques, créatures abyssales |
 
+---
+
 ### 💥 Système de Destruction Environnementale
+
+---
 
 #### Types d'Événements Naturels
 - **🔥 Explosions** - Dégâts en zone avec onde de choc
@@ -48,7 +56,11 @@ Le système de monde complexe transforme le jeu 2D pixel adventure en un univers
 - **🏔️ Avalanches** - Chute de neige et rochers
 - **🌫️ Tempêtes de sable** - Visibilité nulle et érosion
 
+---
+
 ### 🐾 Intelligence Artificielle des Animaux
+
+---
 
 #### 100+ Espèces Animales Intelligentes
 Les animaux utilisent tous les assets existants avec des comportements adaptatifs :
@@ -71,7 +83,11 @@ Les animaux utilisent tous les assets existants avec des comportements adaptatif
 - Événements naturels
 - Proximité du joueur
 
+---
+
 ### 🛠️ Outils d'Exploration Avancés
+
+---
 
 #### 8 Outils Légendaires
 1. **⚡ Quantum Pickaxe** - Minage instantané et téléportation
@@ -83,6 +99,8 @@ Les animaux utilisent tous les assets existants avec des comportements adaptatif
 7. **👁️ Omniscient Eye** - Vision à travers la matière
 8. **⏰ Temporal Stabilizer** - Manipulation du temps
 
+---
+
 #### 6 Blueprints de Construction
 1. **🏰 Fortress** - Forteresse défensive
 2. **🔬 Laboratory** - Station de recherche
@@ -91,7 +109,11 @@ Les animaux utilisent tous les assets existants avec des comportements adaptatif
 5. **🏛️ Temple** - Sanctuaire mystique
 6. **🏭 Factory** - Complexe industriel
 
+---
+
 ### 🏛️ Système de Landmarks
+
+---
 
 #### Types de Landmarks
 - **🏛️ Ancient Ruins** - Ruines mystérieuses
@@ -109,6 +131,8 @@ Les animaux utilisent tous les assets existants avec des comportements adaptatif
 
 ## 🎮 Utilisation et Intégration
 
+---
+
 ### Intégration dans le Jeu Principal
 
 ```javascript
@@ -118,6 +142,8 @@ import { integrateComplexWorld } from './gameIntegration.js';
 // Initialisation
 game.worldIntegration = integrateComplexWorld(game, config);
 ```
+
+---
 
 ### Commandes de Debug Disponibles
 
@@ -144,6 +170,8 @@ window.complexWorld.getStatus();
 
 ## 🧪 Tests et Démonstration
 
+---
+
 ### Test Autonome
 Ouvrez [`test-standalone.html`](test-standalone.html) dans un navigateur pour une démonstration interactive complète.
 
@@ -155,6 +183,8 @@ Ouvrez [`test-standalone.html`](test-standalone.html) dans un navigateur pour un
 - ✅ Effets visuels et particules
 - ✅ Interface utilisateur dynamique
 
+---
+
 ### Résultats des Tests
 - **Performance** : 60 FPS avec 15+ animaux actifs
 - **Mémoire** : Gestion optimisée des particules et effets
@@ -162,6 +192,8 @@ Ouvrez [`test-standalone.html`](test-standalone.html) dans un navigateur pour un
 - **Stabilité** : Aucun crash détecté lors des tests intensifs
 
 ## 📊 Statistiques du Système
+
+---
 
 ### Métriques Techniques
 - **12 biomes** uniques avec caractéristiques distinctes
@@ -171,6 +203,8 @@ Ouvrez [`test-standalone.html`](test-standalone.html) dans un navigateur pour un
 - **12 types de landmarks** à découvrir
 - **6 blueprints** de construction
 
+---
+
 ### Performance
 - **Rendu** : Canvas 2D optimisé avec culling
 - **IA** : Système d'états finis pour les animaux
@@ -178,6 +212,8 @@ Ouvrez [`test-standalone.html`](test-standalone.html) dans un navigateur pour un
 - **Mémoire** : Garbage collection optimisée
 
 ## 🔧 Configuration et Personnalisation
+
+---
 
 ### Configuration des Biomes
 ```javascript
@@ -189,6 +225,8 @@ const biomeConfig = {
     weatherEffects: ['snow', 'blizzard']
 };
 ```
+
+---
 
 ### Configuration des Animaux
 ```javascript
@@ -206,6 +244,8 @@ const animalConfig = {
 
 ## 🚀 Évolutions Futures
 
+---
+
 ### Fonctionnalités Prévues
 - **🌐 Multijoueur** - Monde partagé entre joueurs
 - **🏗️ Construction avancée** - Villes et civilisations
@@ -213,6 +253,8 @@ const animalConfig = {
 - **🌌 Dimensions parallèles** - Voyages interdimensionnels
 - **🎯 Quêtes dynamiques** - Missions générées procéduralement
 - **📈 Économie complexe** - Commerce et ressources
+
+---
 
 ### Optimisations Techniques
 - **🔄 Web Workers** - Calculs IA en arrière-plan
@@ -222,11 +264,15 @@ const animalConfig = {
 
 ## 📝 Notes de Développement
 
+---
+
 ### Défis Résolus
 1. **Intégration sans rupture** - Le système s'intègre parfaitement au jeu existant
 2. **Performance avec 100+ animaux** - Optimisation de l'IA et du rendu
 3. **Gestion mémoire** - Pool d'objets et nettoyage automatique
 4. **Compatibilité navigateurs** - Code vanilla JavaScript moderne
+
+---
 
 ### Leçons Apprises
 - L'architecture modulaire facilite les tests et la maintenance

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 ## Fonctionnalités Implémentées
 
+---
+
 ### 🎮 Système de Jeu Principal
 - ✅ Moteur de jeu avec boucle de rendu optimisée
 - ✅ Génération procédurale de monde infini
 - ✅ Système de physique avec gravité et collisions
 - ✅ Caméra avec suivi du joueur et effets de tremblement
+
+---
 
 ### 👤 Joueur et Contrôles
 - ✅ Personnage avec animations (marche, course, saut, vol, nage)
@@ -15,6 +19,8 @@
 - ✅ Combat au corps à corps avec zone d'attaque
 - ✅ Système de statistiques (niveau, XP, santé, force, défense, vitesse)
 
+---
+
 ### 🌍 Monde et Environnement
 - ✅ 31 types de blocs différents (terre, pierre, minerais, etc.)
 - ✅ Système de biomes avec effets (Surface, Souterrain, Enfer, Paradis, Espace, etc.)
@@ -22,17 +28,23 @@
 - ✅ Système de minage avec progression et particules
 - ✅ Collecte automatique d'objets
 
+---
+
 ### 🌦️ Effets Météorologiques
 - ✅ 6 types de météo (Clair, Pluie, Orage, Neige, Brouillard, Tempête de sable)
 - ✅ Particules météo dynamiques
 - ✅ Éclairs pendant les orages
 - ✅ Effets sur les statistiques du joueur
 
+---
+
 ### 💡 Système d'Éclairage
 - ✅ Éclairage dynamique avec sources de lumière
 - ✅ Calcul d'ombres et d'obstacles
 - ✅ Lumière ambiante variable selon le biome
 - ✅ Torches et sources de lumière magiques
+
+---
 
 ### 👹 Ennemis et Combat
 - ✅ 5 types d'ennemis (Slime, Grenouille, Golem, Démon, Dragon)
@@ -42,11 +54,15 @@
 - ✅ Nombres de dégâts flottants
 - ✅ Récompenses XP pour les victoires
 
+---
+
 ### 👥 PNJ et Interactions
 - ✅ Génération de PNJ avec noms aléatoires
 - ✅ Dialogues interactifs
 - ✅ Système de réputation
 - ✅ Échanges et commerce
+
+---
 
 ### 🎯 Système de Quêtes
 - ✅ 10+ quêtes avec objectifs variés
@@ -54,11 +70,15 @@
 - ✅ Récompenses (XP, objets)
 - ✅ Interface de quêtes avec onglets
 
+---
+
 ### 🎒 Inventaire et Crafting
 - ✅ Inventaire de 32 emplacements
 - ✅ Système de crafting avec recettes
 - ✅ Interface glisser-déposer
 - ✅ Gestion automatique des stacks
+
+---
 
 ### 🗺️ Minimap
 - ✅ Minimap en temps réel
@@ -66,11 +86,15 @@
 - ✅ Zoom et redimensionnement
 - ✅ Légende avec couleurs
 
+---
+
 ### ⏰ Système Temporel
 - ✅ Cycle jour/nuit
 - ✅ Calendrier avec jours/mois/années
 - ✅ Effets visuels selon l'heure
 - ✅ Vitesse de temps configurable
+
+---
 
 ### 🎨 Effets Visuels
 - ✅ Système de particules avancé
@@ -78,11 +102,15 @@
 - ✅ Effets de minage et de combat
 - ✅ Transitions de couleur du ciel
 
+---
+
 ### 🔊 Audio
 - ✅ Gestionnaire de sons
 - ✅ Musique d'ambiance par biome
 - ✅ Effets sonores d'actions
 - ✅ Contrôle du volume
+
+---
 
 ### 💾 Sauvegarde
 - ✅ Système de sauvegarde complet
@@ -91,12 +119,16 @@
 - ✅ Export/Import de sauvegardes
 - ✅ Raccourcis Ctrl+S/Ctrl+L
 
+---
+
 ### ⚙️ Configuration
 - ✅ Menu d'options complet
 - ✅ Distance de rendu configurable
 - ✅ Zoom ajustable
 - ✅ Activation/désactivation des effets
 - ✅ Mode mobile
+
+---
 
 ### 📊 Interface Utilisateur
 - ✅ HUD avec statistiques du joueur
@@ -107,6 +139,8 @@
 
 ## Contrôles
 
+---
+
 ### Mouvement
 - **WASD** ou **Flèches** : Déplacement
 - **Espace** : Saut (double saut disponible)
@@ -115,11 +149,15 @@
 - **S** (maintenu) : S'accroupir
 - **S + Shift** : Ramper
 
+---
+
 ### Actions
 - **Clic gauche** : Miner/Attaquer
 - **Clic droit** : Placer des blocs
 - **1-7** : Sélectionner un outil
 - **Molette** : Changer d'outil
+
+---
 
 ### Interface
 - **Tab** : Inventaire
@@ -128,11 +166,15 @@
 - **M** : Basculer la minimap
 - **Échap** : Menu pause
 
+---
+
 ### Raccourcis
 - **Ctrl+S** : Sauvegarde rapide
 - **Ctrl+L** : Chargement rapide
 
 ## Architecture Technique
+
+---
 
 ### Modules JavaScript
 - `engine.js` - Moteur de jeu principal
@@ -148,6 +190,8 @@
 - `minimap.js` - Carte miniature
 - `fx.js` - Effets visuels
 - `sound.js` - Gestion audio
+
+---
 
 ### Optimisations
 - Rendu par chunks pour les performances


### PR DESCRIPTION
## Summary
- add horizontal separators between major sections in README
- add similar separators in complex world documentation for clarity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f959ff27c832ba03d2ab9c1d647e7