### PR TITLE
feat: enhance seed map logic

### DIFF
--- a/seedMap.js
+++ b/seedMap.js
@@ -1,0 +1,32 @@
+// seedMap.js - Gestion avancée des seeds par chunk
+// Ce module fournit un système de seed déterministe basé sur une seed globale et des coordonnées.
+// Chaque chunk ou combinaison de coordonnées reçoit une seed unique mais reproductible.
+
+export class SeedMap {
+    constructor(baseSeed = 0) {
+        this.baseSeed = baseSeed >>> 0; // Assurer un entier positif
+        this.seedCache = new Map();
+    }
+
+    setBaseSeed(seed) {
+        this.baseSeed = seed >>> 0;
+        this.seedCache.clear();
+    }
+
+    // Récupère la seed pour une paire de coordonnées (x, y)
+    getSeed(x, y = 0) {
+        const key = `${x}:${y}`;
+        if (!this.seedCache.has(key)) {
+            this.seedCache.set(key, this.computeSeed(x, y));
+        }
+        return this.seedCache.get(key);
+    }
+
+    // Algorithme de hachage inspiré de techniques de mixage de bits pour une bonne distribution
+    computeSeed(x, y) {
+        let h = this.baseSeed ^ (x * 374761393) ^ (y * 668265263);
+        h = (h ^ (h >> 13)) * 1274126177;
+        h = h ^ (h >> 16);
+        return h >>> 0; // Convertir en entier non signé
+    }
+}

--- a/world.js
+++ b/world.js
@@ -3,9 +3,10 @@ import { Perlin } from './perlin.js';
 import { Slime, Frog, Golem } from './enemy.js';
 import { PNJ } from './PNJ.js';
 import { generatePNJ } from './generateurPNJ.js';
+import { SeedMap } from './seedMap.js';
 
 // --- LISTE DE BLOCS ---
-export const TILE = { 
+export const TILE = {
     AIR: 0, GRASS: 1, DIRT: 2, STONE: 3, WOOD: 4, LEAVES: 5, COAL: 6, IRON: 7,
     BEDROCK: 8, WATER: 9, CRYSTAL: 10, GLOW_MUSHROOM: 11, CLOUD: 12, HELLSTONE: 13, LAVA: 14,
     SAND: 15, OAK_WOOD: 16, OAK_LEAVES: 17, FLOWER_RED: 18, FLOWER_YELLOW: 19,
@@ -22,6 +23,8 @@ export const TILE = {
     HELLFIRE_CRYSTAL: 68, DEMON_GOLD: 69
 };
 
+const seedMap = new SeedMap();
+
 function generateColumns(game, config, startX, width) {
     const worldHeightInTiles = game.tileMap.length;
     const { tileSize } = config;
@@ -37,8 +40,9 @@ function generateColumns(game, config, startX, width) {
     for (let x = startX; x < startX + width; x++) {
         // === GÉNÉRATION DE TERRAIN ULTRA-COMPLEXE ET VARIÉ ===
         
-        // Seed unique pour chaque monde basé sur la position
-        const worldSeed = Math.floor(x / 1000) * 1337 + 42;
+        // Seed unique par chunk basé sur la seed globale
+        const chunkX = Math.floor(x / (config.chunkSize || 16));
+        const worldSeed = seedMap.getSeed(chunkX);
         SeededRandom.setSeed(worldSeed);
         
         // Bruit continental avec variations extrêmes
@@ -530,6 +534,7 @@ function generateColumns(game, config, startX, width) {
 export function generateLevel(game, config) {
     SeededRandom.setSeed(config.seed || Date.now());
     Perlin.seed();
+    seedMap.setBaseSeed(SeededRandom.seed);
 
     const { worldWidth = 4096, worldHeight, tileSize } = config;
     const worldHeightInTiles = Math.floor(worldHeight / tileSize);


### PR DESCRIPTION
## Summary
- implement SeedMap module to derive deterministic seeds per chunk
- integrate SeedMap with world generation for varied chunk seeding

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f95b2dfa8832ba82d0f00e7c59dd9