### PR TITLE
Restore tool switching via number keys

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -107,8 +107,10 @@ export class GameEngine {
             if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') this.keys.run = true;
             if (e.code === 'KeyV' && !e.repeat) this.keys.fly = !this.keys.fly;
             if (e.code.startsWith('Digit')) {
-                const index = parseInt(e.code.replace('Digit', '')) - 1;
-                if (this.gameLogic.selectTool) this.gameLogic.selectTool(index);
+                const digit = parseInt(e.code.slice(5));
+                if (digit >= 1 && digit <= 6 && this.gameLogic.selectTool) {
+                    this.gameLogic.selectTool(digit - 1);
+                }
             }
             if (e.code === 'KeyO' || e.code === 'Escape') {
                 e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -574,20 +574,23 @@
                     } else {
                         openMenu(ui.menus.quests);
                     }
-                } else if (e.key >= '1' && e.key <= '7') {
-                    // Sélection d'outils avec les chiffres
-                    const toolIndex = parseInt(e.key) - 1;
-                    console.log(`Tentative de sélection outil ${toolIndex}`);
-                    if (window.game && window.game.player && toolIndex < window.game.player.tools.length) {
-                        window.game.player.selectedToolIndex = toolIndex;
-                        window.game.updateToolbar();
-                        console.log(`Outil sélectionné: ${window.game.player.tools[toolIndex]}`);
-                    } else {
-                        console.log("Impossible de sélectionner l'outil:", {
-                            hasGame: !!window.game,
-                            hasPlayer: !!(window.game && window.game.player),
-                            toolsLength: window.game?.player?.tools?.length
-                        });
+                } else if (e.code && e.code.startsWith('Digit')) {
+                    const digit = parseInt(e.code.slice(5));
+                    if (digit >= 1 && digit <= 6) {
+                        // Sélection d'outils avec les chiffres
+                        const toolIndex = digit - 1;
+                        console.log(`Tentative de sélection outil ${toolIndex}`);
+                        if (window.game && window.game.player && toolIndex < window.game.player.tools.length) {
+                            window.game.player.selectedToolIndex = toolIndex;
+                            window.game.updateToolbar();
+                            console.log(`Outil sélectionné: ${window.game.player.tools[toolIndex]}`);
+                        } else {
+                            console.log("Impossible de sélectionner l'outil:", {
+                                hasGame: !!window.game,
+                                hasPlayer: !!(window.game && window.game.player),
+                                toolsLength: window.game?.player?.tools?.length
+                            });
+                        }
                     }
                 } else if (e.ctrlKey && e.key === 's' && window.game) {
                     // Sauvegarde rapide


### PR DESCRIPTION
## Summary
- restore tool switching using number keys 1-6 by relying on `e.code` for keyboard layout independence
- limit engine-level digit handling to the first six slots to match hotbar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f97afe000832baafa9cd7b1360a5c