### PR TITLE
Reduce tool size in player hands

### DIFF
--- a/player.js
+++ b/player.js
@@ -524,7 +524,7 @@ export class Player {
         if (toolName) {
             const toolAsset = assets[`tool_${toolName}`];
             if (toolAsset) {
-                const toolSize = this.w;
+                const toolSize = this.w * 0.6; // Shrink tool relative to player size
                 const handOffsetX = this.dir === 1 ? this.w * 0.7 : this.w * 0.3;
                 const handOffsetY = this.h * 0.5;
                 const pivotX = this.x + handOffsetX;

--- a/test-mining.js
+++ b/test-mining.js
@@ -9,7 +9,8 @@ const mockGame = {
         tools: ['pickaxe', 'bow'],
         selectedToolIndex: 0,
         miningTarget: { x: 0, y: 0, type: TILE.STONE },
-        miningProgress: 0
+        miningProgress: 0,
+        durability: { pickaxe: 100, bow: 100 }
     },
     miningEffect: null
 };


### PR DESCRIPTION
## Summary
- Shrink held tools to 60% of player width so they fit the player's hands.
- Update mining test to include durability data.

## Testing
- `node test-player.js`
- `node test-mining.js`


------
https://chatgpt.com/codex/tasks/task_e_688f9a0a7004832bbe9ef746d27c5da2