### PR TITLE
feat: enable pnj interaction

### DIFF
--- a/PNJ.js
+++ b/PNJ.js
@@ -18,8 +18,12 @@ export class PNJ {
         this.direction = 1;
         this.actionTimer = 120 + Math.random() * 120; // Temps avant de changer d'action
         this.isGrounded = false;
-        
+
         this.image = this.createImage(pnjData.appearance, pnjData.archetype);
+
+        // Interaction
+        this.playerNearby = false;
+        this.interactionCooldown = 0;
     }
 
     createImage(appearance, archetype) {
@@ -71,6 +75,10 @@ export class PNJ {
 
         this.vy += this.config.physics.gravity;
         this.handleCollisions(game);
+
+        if (this.interactionCooldown > 0) {
+            this.interactionCooldown--;
+        }
     }
     
     handleCollisions(game) {
@@ -119,6 +127,13 @@ export class PNJ {
     draw(ctx) {
         if (this.image.complete) {
             ctx.drawImage(this.image, this.x, this.y, this.w, this.h);
+        }
+
+        if (this.playerNearby) {
+            ctx.font = '12px "VT323"';
+            ctx.fillStyle = 'white';
+            ctx.textAlign = 'center';
+            ctx.fillText('[E]', this.x + this.w / 2, this.y - 5);
         }
     }
 }

--- a/game.js
+++ b/game.js
@@ -344,7 +344,20 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             game.player.update(keys, mouse, game, delta);
             game.enemies.forEach(e => e.update(game, delta));
-            game.pnjs.forEach(p => p.update(game, delta));
+            game.pnjs.forEach(p => {
+                p.update(game, delta);
+
+                const dx = (p.x + p.w / 2) - (game.player.x + game.player.w / 2);
+                const dy = (p.y + p.h / 2) - (game.player.y + game.player.h / 2);
+                const dist = Math.hypot(dx, dy);
+                p.playerNearby = dist < config.tileSize * 2;
+
+                if (p.playerNearby && keys.action && p.interactionCooldown <= 0) {
+                    const dialogue = p.data?.quest?.dialogues?.greeting || 'Bonjour';
+                    game.logger.log(`${p.data?.name || 'PNJ'}: ${dialogue}`);
+                    p.interactionCooldown = 30;
+                }
+            });
             
             game.collectibles.forEach(c => {
                 c.vy += config.physics.gravity * 0.5;


### PR DESCRIPTION
## Summary
- show `[E]` hint over PNJ when the player is nearby
- log a simple greeting when interacting with PNJ using **E**

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f9bf1a81c832bb6f9f4d7fb9c1588