### PR TITLE
Remove missing player idle frame to stop red square

### DIFF
--- a/game.js
+++ b/game.js
@@ -44,7 +44,7 @@ async function loadConfig() {
                 "hitbox": { "offsetX": 8, "offsetY": 8, "width": 48, "height": 48 }
             },
             "playerAnimations": {
-                "idle": ["player_idle1", "player_idle2"],
+                "idle": ["player_idle1"],
                 "walking": ["player_walk1", "player_walk2"],
                 "running": ["player_run1", "player_run2"],
                 "jumping": ["player_jump"],

--- a/generate_sprites.js
+++ b/generate_sprites.js
@@ -51,7 +51,6 @@ function drawBase(pose){
 // simple frame variations
 const frames={
   player_idle1: drawBase('stand'),
-  player_idle2: drawBase('stand'),
   player_walk1: drawBase('stand'),
   player_walk2: drawBase('stand'),
   player_run1: drawBase('stand'),

--- a/index.html
+++ b/index.html
@@ -854,7 +854,7 @@
                         "hitbox": { "offsetX": 4, "offsetY": 4, "width": 24, "height": 24 }
                     },
                     "playerAnimations": {
-                        "idle": ["player_idle1", "player_idle2"],
+                        "idle": ["player_idle1"],
                         "walking": ["player_walk1", "player_walk2"],
                         "running": ["player_run1", "player_run2"],
                         "jumping": ["player_jump"],


### PR DESCRIPTION
## Summary
- use only existing `player_idle1` sprite for idle animation
- clean up sprite generator to omit nonexistent `player_idle2`

## Testing
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_688f9eefa980832b91357a0fad141fd2