### PR TITLE
Add disaster trigger menu

### DIFF
--- a/disasterManager.js
+++ b/disasterManager.js
@@ -108,6 +108,16 @@ export class DisasterManager {
         };
     }
 
+    triggerDisaster(type, options = {}) {
+        this.startDisaster(type);
+        if (options.intensity !== undefined) {
+            this.activeDisaster.intensity = options.intensity;
+        }
+        if (options.duration !== undefined) {
+            this.activeDisaster.duration = options.duration;
+        }
+    }
+
     stopDisaster() {
         this.activeDisaster = null;
     }

--- a/index.html
+++ b/index.html
@@ -281,6 +281,24 @@
             pointer-events: all;
         }
 
+        #disasterMenu {
+            position: absolute;
+            top: 50%;
+            right: 20px;
+            transform: translateY(-50%);
+            background: rgba(0,0,0,0.6);
+            border: 2px solid #666;
+            border-radius: 8px;
+            padding: 10px;
+            pointer-events: none;
+            font-size: 14px;
+            line-height: 1.4;
+        }
+
+        #disasterMenu p {
+            margin: 0 0 4px 0;
+        }
+
         .inventory-slot {
             width: 50px;
             height: 50px;
@@ -367,8 +385,13 @@
                 <div id="biomeDisplay">
                     <span id="currentBiome">Surface</span>
                 </div>
-             </div>
-             <div id="minimap"></div>
+            </div>
+            <div id="disasterMenu">
+                <p><strong>F1</strong> : Orage</p>
+                <p><strong>F2</strong> : Tremblement de terre</p>
+                <p><strong>F3</strong> : Pluie de météores</p>
+            </div>
+            <div id="minimap"></div>
         </div>
 
         <!-- ÉCRAN TITRE / MENU PRINCIPAL -->
@@ -934,6 +957,23 @@
             document.addEventListener('keydown', (e) => {
                 keys[e.key] = true;
                 keys[e.code] = true;
+
+                if (window.game && window.game.disasterManager) {
+                    switch (e.key) {
+                        case 'F1':
+                            e.preventDefault();
+                            window.game.disasterManager.startDisaster('thunderstorm');
+                            break;
+                        case 'F2':
+                            e.preventDefault();
+                            window.game.disasterManager.startDisaster('earthquake');
+                            break;
+                        case 'F3':
+                            e.preventDefault();
+                            window.game.disasterManager.startDisaster('meteor_shower');
+                            break;
+                    }
+                }
             });
 
             document.addEventListener('keyup', (e) => {


### PR DESCRIPTION
## Summary
- Add right-side disaster menu with F1–F3 shortcuts for thunderstorm, earthquake, and meteor shower events
- Implement keyboard handlers to trigger disasters and provide debug method in DisasterManager

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f9f3f3aa4832b8fefca5d8eb50a23