### PR TITLE
feat: allow upward flight

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -11,6 +11,7 @@ export class GameEngine {
         this.keys = {
             left: false, right: false, jump: false, action: false,
             fly: false, down: false, run: false, repair: false,
+            up: false,
         };
         this.mouse = { x: 0, y: 0, left: false, right: false };
         this.gameLogic = {};
@@ -102,7 +103,10 @@ export class GameEngine {
             if (e.code === 'ArrowLeft' || e.code === 'KeyA') this.keys.left = true;
             if (e.code === 'ArrowRight' || e.code === 'KeyD') this.keys.right = true;
             if (e.code === 'KeyE') this.keys.action = true;
-            if (e.code === 'Space' || e.code === 'ArrowUp' || e.code === 'KeyW') this.keys.jump = true;
+            if (e.code === 'Space' || e.code === 'ArrowUp' || e.code === 'KeyW') {
+                this.keys.jump = true;
+                this.keys.up = true;
+            }
             if (e.code === 'ArrowDown' || e.code === 'KeyS') this.keys.down = true;
             if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') this.keys.run = true;
             if (e.code === 'KeyR') this.keys.repair = true;
@@ -122,7 +126,10 @@ export class GameEngine {
             if (e.code === 'ArrowLeft' || e.code === 'KeyA') this.keys.left = false;
             if (e.code === 'ArrowRight' || e.code === 'KeyD') this.keys.right = false;
             if (e.code === 'KeyE') this.keys.action = false;
-            if (e.code === 'Space' || e.code === 'ArrowUp' || e.code === 'KeyW') this.keys.jump = false;
+            if (e.code === 'Space' || e.code === 'ArrowUp' || e.code === 'KeyW') {
+                this.keys.jump = false;
+                this.keys.up = false;
+            }
             if (e.code === 'ArrowDown' || e.code === 'KeyS') this.keys.down = false;
             if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') this.keys.run = false;
             if (e.code === 'KeyR') this.keys.repair = false;

--- a/player.js
+++ b/player.js
@@ -127,12 +127,12 @@ export class Player {
 
         if (this.isFlying) {
             this.vx = keys.left ? -speed : keys.right ? speed : 0;
-            this.vy = keys.jump ? -speed : keys.down ? speed : 0;
+            this.vy = keys.up ? -speed : keys.down ? speed : 0;
             this.grounded = false;
         } else if (this.inWater) {
             const swimSpeed = physics.playerSpeed * 0.5;
             this.vx = keys.left ? -swimSpeed : keys.right ? swimSpeed : this.vx * 0.9;
-            if (keys.jump) {
+            if (keys.up || keys.jump) {
                 this.vy = -swimSpeed;
             } else if (keys.down) {
                 this.vy = swimSpeed;

--- a/test-player.js
+++ b/test-player.js
@@ -77,7 +77,7 @@ try {
     };
     
     const mockMouse = { x: 0, y: 0, left: false, right: false };
-    const mockKeys = { left: false, right: false, jump: false, down: false, run: false, fly: false };
+    const mockKeys = { left: false, right: false, jump: false, down: false, run: false, fly: false, up: false };
     
     console.log('Testing updateCombat method...');
     player.updateCombat(mockGame, 16);


### PR DESCRIPTION
## Summary
- add dedicated `up` key to engine input handling
- use `up` key for ascending when flying or swimming
- adjust tests for new key field

## Testing
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_688f9f12e2c4832b88b9c03658c28ac2