### PR TITLE
Reduce player hitbox to match character size

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,10 +43,10 @@
     "height": 64,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 8,
-      "offsetY": 8,
-      "width": 48,
-      "height": 48
+      "offsetX": 0,
+      "offsetY": 0,
+      "width": 64,
+      "height": 64
     },
     "reach": 4,
     "attackRange": 20

--- a/game.js
+++ b/game.js
@@ -41,7 +41,7 @@ async function loadConfig() {
             "player": {
                 "width": 64,
                 "height": 64,
-                "hitbox": { "offsetX": 8, "offsetY": 8, "width": 48, "height": 48 }
+                "hitbox": { "offsetX": 0, "offsetY": 0, "width": 64, "height": 64 }
             },
             "playerAnimations": {
                 "idle": ["player_idle1"],

--- a/index.html
+++ b/index.html
@@ -874,7 +874,7 @@
                     "player": {
                         "width": 32,
                         "height": 32,
-                        "hitbox": { "offsetX": 4, "offsetY": 4, "width": 24, "height": 24 }
+                        "hitbox": { "offsetX": 0, "offsetY": 0, "width": 32, "height": 32 }
                     },
                     "playerAnimations": {
                         "idle": ["player_idle1"],

--- a/player.js
+++ b/player.js
@@ -8,11 +8,12 @@ export class Player {
         this.vx = 0; this.vy = 0;
         this.w = config.player.width;
         this.h = config.player.height;
+        // Hitbox now matches the player dimensions exactly
         this.hitbox = {
-            offsetX: config.player.hitbox.offsetX,
-            offsetY: config.player.hitbox.offsetY,
-            width: config.player.hitbox.width,
-            height: config.player.hitbox.height
+            offsetX: 0,
+            offsetY: 0,
+            width: this.w,
+            height: this.h
         };
         this.config = config;
         this.sound = sound;

--- a/test-player.js
+++ b/test-player.js
@@ -21,7 +21,7 @@ const mockConfig = {
     player: {
         width: 32,
         height: 32,
-        hitbox: { offsetX: 4, offsetY: 4, width: 24, height: 24 },
+        hitbox: { offsetX: 0, offsetY: 0, width: 32, height: 32 },
         reach: 4
     },
     physics: {


### PR DESCRIPTION
## Summary
- Set player hitbox to exact character dimensions with no offset
- Update fallback configs and tests to reflect new hitbox

## Testing
- `node test-player.js`
- `node test-player-assets.js`


------
https://chatgpt.com/codex/tasks/task_e_688fa0e0de8c832baaf91de5d2be33f1