### PR TITLE
Move disaster trigger menu to bottom-left

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,9 +283,8 @@
 
         #disasterMenu {
             position: absolute;
-            top: 50%;
-            right: 20px;
-            transform: translateY(-50%);
+            bottom: 20px;
+            left: 20px;
             background: rgba(0,0,0,0.6);
             border: 2px solid #666;
             border-radius: 8px;


### PR DESCRIPTION
## Summary
- Reposition disaster event menu to bottom-left of the HUD for easier access

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fa3bb9a64832bbcb4f930c79c10ab