### PR TITLE
fix: allow opening chests

### DIFF
--- a/index.html
+++ b/index.html
@@ -948,7 +948,7 @@
                 jump: keys[' '] || keys['Space'],
                 run: keys['Shift'],
                 fly: keys['v'] || keys['V'] || keys['KeyV'],
-                interact: keys['e'] || keys['E']
+                action: keys['e'] || keys['E']
             });
 
             const getMouse = () => mouse;


### PR DESCRIPTION
## Summary
- map E key to `action` for in-game interactions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fa42934f8832bbccccd65f105e4d7