### PR TITLE
Reduce player hitbox for narrow passages

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,10 +43,10 @@
     "height": 64,
     "collisionMargin": 0,
     "hitbox": {
-      "offsetX": 0,
-      "offsetY": 0,
-      "width": 64,
-      "height": 64
+      "offsetX": 16,
+      "offsetY": 8,
+      "width": 32,
+      "height": 48
     },
     "reach": 4,
     "attackRange": 20

--- a/player.js
+++ b/player.js
@@ -8,12 +8,13 @@ export class Player {
         this.vx = 0; this.vy = 0;
         this.w = config.player.width;
         this.h = config.player.height;
-        // Hitbox now matches the player dimensions exactly
+        // Allow a custom hitbox that's smaller than the sprite
+        const hb = config.player.hitbox || {};
         this.hitbox = {
-            offsetX: 0,
-            offsetY: 0,
-            width: this.w,
-            height: this.h
+            offsetX: hb.offsetX ?? 0,
+            offsetY: hb.offsetY ?? 0,
+            width: hb.width ?? this.w,
+            height: hb.height ?? this.h
         };
         this.config = config;
         this.sound = sound;


### PR DESCRIPTION
## Summary
- Make player hitbox configurable and default to smaller size than sprite
- Shrink default hitbox to 32x48 with offsets so the character fits narrow areas

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fae5a7bc4832b9efed3aaa164b0f4