### PR TITLE
Reduce tool sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,8 +188,8 @@
             pointer-events: all;
         }
         .toolbar-slot {
-            width: 50px;
-            height: 50px;
+            width: 40px;
+            height: 40px;
             border: 2px solid #888;
             background: rgba(0,0,0,0.5);
             display: flex;
@@ -204,8 +204,8 @@
             transform: scale(1.1);
         }
         .toolbar-slot img {
-            width: 80%;
-            height: 80%;
+            width: 70%;
+            height: 70%;
             image-rendering: pixelated;
         }
 

--- a/player.js
+++ b/player.js
@@ -577,7 +577,7 @@ export class Player {
         if (toolName) {
             const toolAsset = assets[`tool_${toolName}`];
             if (toolAsset) {
-                const toolSize = this.w * 0.6; // Shrink tool relative to player size
+                const toolSize = this.w * 0.45; // Shrink tool relative to player size
                 const handOffsetX = this.dir === 1 ? this.w * 0.7 : this.w * 0.3;
                 const handOffsetY = this.h * 0.5;
                 const pivotX = this.x + handOffsetX;


### PR DESCRIPTION
## Summary
- Shrink toolbar tool icons for a less bulky interface
- Reduce player-held tool scale to better fit character

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fae639eac832baa934aefe4fbb04e