### PR TITLE
Ensure all player assets are referenced

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,9 +52,23 @@
     "attackRange": 20
   },
   "skins": [
+    "player_crouch.png",
+    "player_crouch_walk1.png",
+    "player_crouch_walk2.png",
+    "player_double_jump1.png",
+    "player_double_jump2.png",
+    "player_fly1.png",
+    "player_fly2.png",
     "player_idle1.png",
+    "player_idle_blink.png",
+    "player_jump.png",
+    "player_prone.png",
+    "player_prone_walk1.png",
+    "player_prone_walk2.png",
     "player_run1.png",
-    "player_walk1.png"
+    "player_run2.png",
+    "player_walk1.png",
+    "player_walk2.png"
   ],
   "assets": {
     "cloud": "assets/cloud.png",

--- a/index.html
+++ b/index.html
@@ -876,7 +876,7 @@
                         "hitbox": { "offsetX": 0, "offsetY": 0, "width": 32, "height": 32 }
                     },
                     "playerAnimations": {
-                        "idle": ["player_idle1"],
+                        "idle": ["player_idle1", "player_idle2"],
                         "walking": ["player_walk1", "player_walk2"],
                         "running": ["player_run1", "player_run2"],
                         "jumping": ["player_jump"],
@@ -2320,7 +2320,7 @@
                                 } else {
                                     // Animation idle avec clignement
                                     const idleFrame = Math.floor(Date.now() / 3000) % 10;
-                                    playerTexture = idleFrame === 0 ? 'player_idle_blink' : 'player_idle1';
+                                    playerTexture = idleFrame === 0 ? 'player_idle2' : 'player_idle1';
                                 }
                                 
                                 const texture = assets[playerTexture];
@@ -2686,8 +2686,13 @@
             // Liste des assets à charger
             const assetList = [
                 // Joueur
-                'player_idle1', 'player_walk1', 'player_walk2', 'player_run1', 'player_run2',
-                'player_jump', 'player_crouch', 'player_prone',
+                'player_idle1', 'player_idle2',
+                'player_walk1', 'player_walk2',
+                'player_run1', 'player_run2',
+                'player_jump', 'player_double_jump1', 'player_double_jump2',
+                'player_fly1', 'player_fly2',
+                'player_crouch', 'player_crouch_walk1', 'player_crouch_walk2',
+                'player_prone', 'player_prone_walk1', 'player_prone_walk2',
                 
                 // Ennemis
                 'enemy_slime', 'enemy_frog', 'enemy_golem',


### PR DESCRIPTION
## Summary
- List every `player_*` sprite in `config.json` so the engine preloads them all
- Expand default configuration and asset preloader in `index.html` to cover every player animation frame
- Use `player_idle2` for the blinking idle frame

## Testing
- `node test-player-assets.js`
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_688fae784a90832bb6f54f21c759967d