### PR TITLE
Allow mining of undefined tiles

### DIFF
--- a/miningEngine.js
+++ b/miningEngine.js
@@ -150,13 +150,16 @@ export function updateMining(game, keys, mouse, delta) {
     
     // Si l'outil n'est pas adapté et qu'on ne peut pas miner à la main, arrêter
     if (toolName !== 'hand' && toolEfficiency === undefined && !handMineable.includes(currentType)) {
-        player.miningProgress = 0;
-        game.miningEffect = null;
-        return; // Outil inadapté : pas de progression de minage
+        if (toolName !== 'pickaxe') {
+            player.miningProgress = 0;
+            game.miningEffect = null;
+            return; // Outil inadapté : pas de progression de minage
+        }
+        // La pioche peut miner les blocs inconnus avec une efficacité par défaut
     }
 
     // Vérifier si l'outil a encore de la durabilité
-    let efficiency = toolEfficiency ?? 0.5; // 0.5 = main nue
+    let efficiency = toolEfficiency ?? (toolName === 'pickaxe' ? 1 : 0.5); // 0.5 = main nue
     
     if (toolName !== 'hand') {
         const durability = player.durability?.[toolName] ?? Infinity;

--- a/test-mining.js
+++ b/test-mining.js
@@ -25,6 +25,17 @@ if (mockGame.player.miningProgress <= 0) {
     process.exit(1);
 }
 
+// Test mining of a block without specific efficiency (e.g., COPPER)
+mockGame.tileMap = [[TILE.COPPER]];
+mockGame.player.miningTarget = { x: 0, y: 0, type: TILE.COPPER };
+mockGame.player.miningProgress = 0;
+mockGame.player.selectedToolIndex = 0; // pickaxe
+updateMining(mockGame, keys, mouse, 0.1);
+if (mockGame.player.miningProgress <= 0) {
+    console.error('❌ Pickaxe should mine unknown block types');
+    process.exit(1);
+}
+
 // Reset and test with a non-mining tool (bow) - progress should stay at 0
 mockGame.player.selectedToolIndex = 1; // bow
 mockGame.player.miningTarget = { x: 0, y: 0, type: TILE.STONE };


### PR DESCRIPTION
## Summary
- Permit pickaxe to mine blocks lacking tool efficiency entries, falling back to a default speed
- Add test verifying pickaxe can break an unsupported tile type

## Testing
- `node test-mining.js`


------
https://chatgpt.com/codex/tasks/task_e_688fb4775180832b91ed1ed00365e26d