### PR TITLE
Ensure default key bindings for player controls

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -7,6 +7,22 @@ export class GameEngine {
         this.ctx = canvas.getContext('2d');
         this.ctx.imageSmoothingEnabled = false;
         this.config = config;
+
+        // Provide default key bindings when none are supplied. This prevents
+        // the player from being unable to move if the configuration misses
+        // the `keyBindings` section.
+        const defaultBindings = {
+            left: 'ArrowLeft',
+            right: 'ArrowRight',
+            jump: 'Space',
+            down: 'ArrowDown',
+            action: 'KeyE',
+            run: 'ShiftLeft',
+            fly: 'KeyV',
+            repair: 'KeyR',
+        };
+        this.config.keyBindings = { ...defaultBindings, ...(config.keyBindings || {}) };
+
         this.assets = {};
         this.keys = {
             left: false, right: false, jump: false, action: false,


### PR DESCRIPTION
## Summary
- provide default key bindings in the game engine
- ensures player can move, jump or fly even when keyBindings are missing from config

## Testing
- `node test-player.js`
- `node test-player-assets.js`


------
https://chatgpt.com/codex/tasks/task_e_688fb8eb689c832b832d199b12bd26b6