### PR TITLE
feat: make in-game menus draggable

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,8 +121,19 @@
             z-index: 30;
         }
         .overlay.active { visibility: visible; opacity: 1; }
-        .overlay .menu-box { transform: scale(0.9); transition: transform 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28); }
-        .overlay.active .menu-box { transform: scale(1); }
+        .overlay .menu-box {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%) scale(0.9);
+            transition: transform 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+            cursor: move;
+        }
+        .overlay.active .menu-box { transform: translate(-50%, -50%) scale(1); }
+        .overlay .menu-box.marked {
+            border-color: var(--primary-color);
+            box-shadow: 0 0 10px var(--primary-color);
+        }
         .menu-box {
             background: linear-gradient(to bottom, #2a2a2a, #1e1e1e);
             border: 4px solid var(--border-color);
@@ -571,6 +582,35 @@
                     document.addEventListener('game-module-ready', launch, { once: true });
                 }
             };
+
+            let zIndexCounter = 100;
+            const makeDraggable = (overlay) => {
+                const box = overlay?.querySelector('.menu-box');
+                if (!box) return;
+                box.addEventListener('mousedown', (e) => {
+                    if (e.target.closest('button')) return;
+                    zIndexCounter++;
+                    box.style.zIndex = zIndexCounter;
+                    const rect = box.getBoundingClientRect();
+                    box.style.left = `${rect.left}px`;
+                    box.style.top = `${rect.top}px`;
+                    box.style.transform = 'none';
+                    const offsetX = e.clientX - rect.left;
+                    const offsetY = e.clientY - rect.top;
+                    const onMouseMove = (ev) => {
+                        box.style.left = `${ev.clientX - offsetX}px`;
+                        box.style.top = `${ev.clientY - offsetY}px`;
+                    };
+                    document.addEventListener('mousemove', onMouseMove);
+                    document.addEventListener('mouseup', () => {
+                        document.removeEventListener('mousemove', onMouseMove);
+                    }, { once: true });
+                });
+                box.addEventListener('dblclick', () => {
+                    box.classList.toggle('marked');
+                });
+            };
+            Object.values(ui.menus).forEach(makeDraggable);
 
             // Écouteurs d'événements
             document.body.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- allow player menus like inventory or character panels to be dragged and marked

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fb962f908832bb7f3a9dda87b2b23