### PR TITLE
feat: add default up key binding

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -16,6 +16,7 @@ export class GameEngine {
             right: 'ArrowRight',
             jump: 'Space',
             down: 'ArrowDown',
+            up: 'ArrowUp',
             action: 'KeyE',
             run: 'ShiftLeft',
             fly: 'KeyV',
@@ -120,6 +121,7 @@ export class GameEngine {
             if (e.code === binds.left) this.keys.left = true;
             if (e.code === binds.right) this.keys.right = true;
             if (e.code === binds.action) this.keys.action = true;
+            if (e.code === binds.up) this.keys.up = true;
             if (e.code === binds.jump) {
                 this.keys.jump = true;
                 this.keys.up = true;
@@ -144,6 +146,7 @@ export class GameEngine {
             if (e.code === binds.left) this.keys.left = false;
             if (e.code === binds.right) this.keys.right = false;
             if (e.code === binds.action) this.keys.action = false;
+            if (e.code === binds.up) this.keys.up = false;
             if (e.code === binds.jump) {
                 this.keys.jump = false;
                 this.keys.up = false;

--- a/game.js
+++ b/game.js
@@ -87,6 +87,7 @@ async function loadOptions() {
                 "right": "ArrowRight",
                 "jump": "Space",
                 "down": "ArrowDown",
+                "up": "ArrowUp",
                 "action": "KeyE",
                 "run": "ShiftLeft",
                 "fly": "KeyV",

--- a/options.json
+++ b/options.json
@@ -11,6 +11,7 @@
     "right": "ArrowRight",
     "jump": "Space",
     "down": "ArrowDown",
+    "up": "ArrowUp",
     "action": "KeyE",
     "run": "ShiftLeft",
     "fly": "KeyV",


### PR DESCRIPTION
## Summary
- ensure ArrowUp has default binding so player can move upward
- include up binding in options defaults

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fc4a15ac4832b956a2954b8a876ff