### PR TITLE
Fix controls menu ReferenceError

### DIFF
--- a/index.html
+++ b/index.html
@@ -1564,6 +1564,8 @@
                     list.appendChild(row);
                 }
             }
+            // Exposer la fonction au scope global pour le script non-module
+            window.syncControlsUI = syncControlsUI;
 
             function setupOptionHandlers() {
                 if (renderDistanceSlider) {


### PR DESCRIPTION
## Summary
- Expose `syncControlsUI` to the global scope so non-module scripts can invoke it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fd61dc5a0832ba0ef2736a1cc2e10