### PR TITLE
Fix player movement by mapping key inputs

### DIFF
--- a/game.js
+++ b/game.js
@@ -456,8 +456,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         update(delta, keys, mouse) {
             if (!game.player) return;
 
-            // Fix: Use getKeys() to map keys properly according to config.keyBindings
-            const mappedKeys = getKeys();
+            // Map raw key states according to config.keyBindings
+            const mappedKeys = this.getKeys(keys);
 
             game.player.update(mappedKeys, mouse, game, delta);
             game.enemies.forEach(e => e.update(game, delta));


### PR DESCRIPTION
## Summary
- Map raw key state to configured bindings in `update` to enable movement

## Testing
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_688fdc42e734832bb63346aa86e1c012