### PR TITLE
Standardise les noms des outils

### DIFF
--- a/combatSystem.js
+++ b/combatSystem.js
@@ -265,12 +265,12 @@ export class CombatSystem {
 
     getWeaponDamage(weapon) {
         const weaponDamage = {
-            'sword': 15,
-            'axe': 12,
-            'pickaxe': 8,
-            'shovel': 6,
-            'knife': 10,
-            'bow': 20
+            'tool_sword': 15,
+            'tool_axe': 12,
+            'tool_pickaxe': 8,
+            'tool_shovel': 6,
+            'tool_knife': 10,
+            'tool_bow': 20
         };
         
         let baseDamage = weaponDamage[weapon.name] || 5;

--- a/engine.js
+++ b/engine.js
@@ -71,9 +71,9 @@ export class GameEngine {
         });
 
         // Ajouter automatiquement les assets des outils
-        const toolNames = ['pickaxe', 'shovel', 'axe', 'sword', 'knife', 'bow', 'fishing_rod'];
-        toolNames.forEach(toolName => {
-            allAssetKeys.add(`tool_${toolName}`);
+        const toolKeys = ['tool_pickaxe', 'tool_shovel', 'tool_axe', 'tool_sword', 'tool_knife', 'tool_bow', 'tool_fishing_rod'];
+        toolKeys.forEach(key => {
+            allAssetKeys.add(key);
         });
 
         if (this.config.playerAnimations) {

--- a/game.js
+++ b/game.js
@@ -254,7 +254,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 // Ajouter un titre pour l'accessibilité avec durabilité
                 const durability = this.player.durability[toolName] || 0;
                 const maxDurability = this.player.toolDurability[toolName] || 100;
-                slot.title = `${toolName.charAt(0).toUpperCase() + toolName.slice(1).replace('_', ' ')} (${durability}/${maxDurability})`;
+                const displayName = toolName.replace(/^tool_/, '');
+                slot.title = `${displayName.charAt(0).toUpperCase() + displayName.slice(1).replace('_', ' ')} (${durability}/${maxDurability})`;
                 
                 const icon = getItemIcon(toolName, this.assets);
                 if (icon) slot.appendChild(icon.cloneNode(true));
@@ -311,7 +312,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const repairMaterial = this.player.getRepairMaterial(toolName);
                 const repairMaterialName = Object.keys(TILE).find(k => TILE[k] === repairMaterial) || 'Matériau';
                 const hasRepairMaterial = (this.player.inventory[repairMaterial] || 0) > 0;
-                
+                const displayName = toolName.replace(/^tool_/, '');
+
                 let statusText = '';
                 if (durability <= 0) {
                     statusText = '<span style="color: #ff4444;">CASSÉ</span>';
@@ -320,10 +322,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 } else if (durability < maxDurability * 0.5) {
                     statusText = '<span style="color: #ffff00;">Usé</span>';
                 }
-                
+
                 toolInfo.innerHTML = `
                     <div style="font-size: 12px; color: #fff;">
-                        <strong>${toolName.charAt(0).toUpperCase() + toolName.slice(1).replace('_', ' ')}</strong><br>
+                        <strong>${displayName.charAt(0).toUpperCase() + displayName.slice(1).replace('_', ' ')}</strong><br>
                         Durabilité: ${durability}/${maxDurability} ${statusText}<br>
                         ${enchantments.length > 0 ? `Enchantements: ${enchantments.join(', ')}<br>` : ''}
                         ${durability < maxDurability ? `Réparation: ${repairMaterialName} ${hasRepairMaterial ? '✓' : '✗'}<br>` : ''}
@@ -711,8 +713,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             const durability = game.player.durability[toolName] || 0;
             const maxDurability = game.player.toolDurability[toolName] || 100;
             const enchantments = game.player.toolEnchantments[toolName] || [];
-            
-            let infoText = `${toolName.charAt(0).toUpperCase() + toolName.slice(1).replace('_', ' ')}`;
+            const displayName = toolName.replace(/^tool_/, '');
+
+            let infoText = `${displayName.charAt(0).toUpperCase() + displayName.slice(1).replace('_', ' ')}`;
             infoText += ` - Durabilité: ${durability}/${maxDurability}`;
             
             if (enchantments.length > 0) {

--- a/generateurQuete.js
+++ b/generateurQuete.js
@@ -15,9 +15,9 @@ const MONSTERS = {
     hell: [{ id: 'monster_hell', name: 'Démon' }],
 };
 
-// Les quêtes doivent référencer les mêmes identifiants d'outils que le joueur.
-// On retire le préfixe "stone_" pour rester cohérent avec les assets.
-const TOOLS = [{ id: 'pickaxe', name: 'Pioche en Pierre' }, { id: 'iron_axe', name: 'Hache en Fer' }];
+// Les quêtes doivent référencer les mêmes identifiants d'outils que le joueur,
+// en utilisant le préfixe "tool_" comme pour les assets.
+const TOOLS = [{ id: 'tool_pickaxe', name: 'Pioche en Pierre' }, { id: 'tool_axe', name: 'Hache en Fer' }];
 
 // --- MODÈLES DE QUÊTES PAR ARCHÉTYPE ---
 
@@ -41,7 +41,7 @@ const QUEST_BLUEPRINTS = {
             type: 'hunt', actionText: 'éliminer',
             targets: MONSTERS.surface,
             amountRange: [5, 10],
-            rewardPool: [{ id: 'sword', name: 'Épée' }, { id: 'bow', name: 'Arc' }]
+            rewardPool: [{ id: 'tool_sword', name: 'Épée' }, { id: 'tool_bow', name: 'Arc' }]
         },
         {
             type: 'hunt', actionText: 'chasser',

--- a/inventorySystem.js
+++ b/inventorySystem.js
@@ -13,8 +13,8 @@ export class InventoryItem {
     getMaxStack() {
         const stackSizes = {
             // Outils (ne se stackent pas)
-            'pickaxe': 1, 'shovel': 1, 'axe': 1, 'sword': 1, 'knife': 1,
-            'bow': 1, 'fishing_rod': 1,
+            'tool_pickaxe': 1, 'tool_shovel': 1, 'tool_axe': 1, 'tool_sword': 1, 'tool_knife': 1,
+            'tool_bow': 1, 'tool_fishing_rod': 1,
             
             // Matériaux (se stackent)
             'wood': 64, 'stone': 64, 'dirt': 64, 'sand': 64,
@@ -231,32 +231,32 @@ export class CraftingSystem {
             ['wood', 'wood', 'wood'],
             [null, 'stick', null],
             [null, 'stick', null]
-        ], { name: 'pickaxe', quantity: 1, metadata: { material: 'wood' } }));
+        ], { name: 'tool_pickaxe', quantity: 1, metadata: { material: 'wood' } }));
 
         this.addRecipe(new CraftingRecipe('wooden_axe', [
             ['wood', 'wood', null],
             ['wood', 'stick', null],
             [null, 'stick', null]
-        ], { name: 'axe', quantity: 1, metadata: { material: 'wood' } }));
+        ], { name: 'tool_axe', quantity: 1, metadata: { material: 'wood' } }));
 
         this.addRecipe(new CraftingRecipe('wooden_shovel', [
             [null, 'wood', null],
             [null, 'stick', null],
             [null, 'stick', null]
-        ], { name: 'shovel', quantity: 1, metadata: { material: 'wood' } }));
+        ], { name: 'tool_shovel', quantity: 1, metadata: { material: 'wood' } }));
 
         this.addRecipe(new CraftingRecipe('wooden_sword', [
             [null, 'wood', null],
             [null, 'wood', null],
             [null, 'stick', null]
-        ], { name: 'sword', quantity: 1, metadata: { material: 'wood' } }));
+        ], { name: 'tool_sword', quantity: 1, metadata: { material: 'wood' } }));
 
         // Outils en pierre
         this.addRecipe(new CraftingRecipe('stone_pickaxe', [
             ['stone', 'stone', 'stone'],
             [null, 'stick', null],
             [null, 'stick', null]
-        ], { name: 'pickaxe', quantity: 1, metadata: { material: 'stone' } }));
+        ], { name: 'tool_pickaxe', quantity: 1, metadata: { material: 'stone' } }));
 
         // Matériaux
         this.addRecipe(new CraftingRecipe('sticks', [

--- a/itemIcons.js
+++ b/itemIcons.js
@@ -7,7 +7,7 @@ function drawIcon(objName, ctx) {
   ctx.save();
   ctx.translate(16,16);
   ctx.scale(1.2, 1.2); // Légère réduction pour mieux voir les bords
-  
+
   // La logique de dessin reste la vôtre, elle est très bien !
   switch(objName) {
     // --- ARMES TRANCHANTES ---
@@ -17,35 +17,35 @@ function drawIcon(objName, ctx) {
     // ... (tous vos autres cas de switch)
     
     // --- Outils ---
-    case "pickaxe": 
+    case "tool_pickaxe":
         ctx.fillStyle="#8B4513"; ctx.fillRect(-1,-8,2,12); // Manche en bois
         ctx.fillStyle="#696969"; ctx.fillRect(-6,-8,12,3); // Tête de pioche
         ctx.fillStyle="#A9A9A9"; ctx.fillRect(-6,-5,12,1); // Reflet
         break;
-    case "shovel": 
+    case "tool_shovel":
         ctx.fillStyle="#8B4513"; ctx.fillRect(-1,-8,2,12); // Manche
         ctx.fillStyle="#696969"; ctx.beginPath(); ctx.arc(0, -6, 4, 0, Math.PI); ctx.fill(); // Pelle
         ctx.fillStyle="#A9A9A9"; ctx.fillRect(-3,-6,6,1); // Reflet
         break;
-    case "axe": 
+    case "tool_axe":
         ctx.fillStyle="#8B4513"; ctx.fillRect(-1,-8,2,12); // Manche
         ctx.fillStyle="#696969"; ctx.beginPath(); ctx.moveTo(-1,-6); ctx.lineTo(-6,-6); ctx.lineTo(-4,-2); ctx.lineTo(4,-2); ctx.lineTo(6,-6); ctx.lineTo(1,-6); ctx.closePath(); ctx.fill(); // Lame
         break;
-    case "sword": 
+    case "tool_sword":
         ctx.fillStyle="#C0C0C0"; ctx.fillRect(-1,-10,2,14); // Lame
         ctx.fillStyle="#8B4513"; ctx.fillRect(-3,4,6,3); // Garde
         ctx.fillStyle="#654321"; ctx.fillRect(-1,4,2,4); // Poignée
         break;
-    case "knife": 
+    case "tool_knife":
         ctx.fillStyle="#C0C0C0"; ctx.fillRect(-1,-6,2,8); // Lame
         ctx.fillStyle="#654321"; ctx.fillRect(-2,2,4,3); // Poignée
         break;
-    case "bow":
+    case "tool_bow":
         ctx.strokeStyle="#8B4513"; ctx.lineWidth=2;
         ctx.beginPath(); ctx.moveTo(0,-8); ctx.quadraticCurveTo(-4,-4,0,0); ctx.quadraticCurveTo(4,-4,0,-8); ctx.stroke(); // Arc
         ctx.strokeStyle="#654321"; ctx.lineWidth=1; ctx.moveTo(-3,-6); ctx.lineTo(3,-6); ctx.stroke(); // Corde
         break;
-    case "fishing_rod":
+    case "tool_fishing_rod":
         ctx.fillStyle="#8B4513"; ctx.fillRect(-1,-8,2,12); // Canne
         ctx.strokeStyle="#654321"; ctx.lineWidth=1; ctx.beginPath(); ctx.moveTo(0,-8); ctx.lineTo(4,-4); ctx.stroke(); // Ligne
         ctx.fillStyle="#C0C0C0"; ctx.beginPath(); ctx.arc(4,-4,1,0,2*Math.PI); ctx.fill(); // Hameçon
@@ -68,7 +68,7 @@ function drawIcon(objName, ctx) {
 // Fonction exportée qui utilise le cache
 export function getItemIcon(name, assets) {
   // Créer une clé de cache unique qui inclut si on utilise un asset ou une icône générée
-  const cacheKey = `${name}_${assets && assets[`tool_${name}`] ? 'asset' : 'generated'}`;
+  const cacheKey = `${name}_${assets && assets[name] ? 'asset' : 'generated'}`;
   
   // Si l'icône est déjà dans le cache, on la retourne directement
   if (iconCache.has(cacheKey)) {
@@ -76,7 +76,7 @@ export function getItemIcon(name, assets) {
   }
   
   // On vérifie d'abord si un asset direct existe (pour les outils)
-  const assetKey = `tool_${name}`;
+  const assetKey = name;
   if (assets && assets[assetKey]) {
       console.log(`Utilisation de l'asset ${assetKey} pour l'outil ${name}`);
       iconCache.set(cacheKey, assets[assetKey]);

--- a/miningEngine.js
+++ b/miningEngine.js
@@ -39,7 +39,7 @@ const BLOCK_BREAK_TIME = {
 
 // Efficacité des outils selon le type de bloc
 const TOOL_EFFICIENCY = {
-    pickaxe: {
+    tool_pickaxe: {
         [TILE.STONE]: 3,
         [TILE.COAL]: 3,
         [TILE.IRON]: 3,
@@ -55,24 +55,24 @@ const TOOL_EFFICIENCY = {
         [TILE.OBSIDIAN]: 1.5,
         [TILE.AMETHYST]: 2.5
     },
-    shovel: {
+    tool_shovel: {
         [TILE.DIRT]: 3,
         [TILE.GRASS]: 3,
         [TILE.SAND]: 3,
         [TILE.GRAVEL]: 3,
         [TILE.SOUL_SAND]: 2
     },
-    axe: {
+    tool_axe: {
         [TILE.WOOD]: 3,
         [TILE.LEAVES]: 3,
         [TILE.OAK_WOOD]: 3,
         [TILE.OAK_LEAVES]: 3
     },
-    sword: {
+    tool_sword: {
         [TILE.LEAVES]: 2,
         [TILE.OAK_LEAVES]: 2
     },
-    knife: {
+    tool_knife: {
         [TILE.LEAVES]: 1.5,
         [TILE.OAK_LEAVES]: 1.5
     }
@@ -162,12 +162,12 @@ export function updateMining(game, keys, mouse, delta) {
         player.miningProgress = 0;
         game.miningEffect = null;
         if (game.logger) game.logger.log(`Impossible de miner ce bloc avec ${toolName}.`);
-        if (toolName !== 'pickaxe') return;
+        if (toolName !== 'tool_pickaxe') return;
         // La pioche peut miner les blocs inconnus avec une efficacité par défaut
     }
 
     // Vérifier si l'outil a encore de la durabilité
-    let efficiency = toolEfficiency ?? (toolName === 'pickaxe' ? 1 : 0.5); // 0.5 = main nue
+    let efficiency = toolEfficiency ?? (toolName === 'tool_pickaxe' ? 1 : 0.5); // 0.5 = main nue
     
     if (toolName !== 'hand') {
         const durability = player.durability?.[toolName] ?? Infinity;

--- a/player.js
+++ b/player.js
@@ -21,7 +21,7 @@ export class Player {
         this.grounded = false;
         this.dir = 1;
         this.swingTimer = 0;
-        this.tools = ['pickaxe', 'shovel', 'axe', 'sword', 'knife', 'bow', 'fishing_rod'];
+        this.tools = ['tool_pickaxe', 'tool_shovel', 'tool_axe', 'tool_sword', 'tool_knife', 'tool_bow', 'tool_fishing_rod'];
         this.selectedToolIndex = 0;
         this.inventory = {};
         this.miningTarget = null;
@@ -29,33 +29,33 @@ export class Player {
         
         // Nouveau système d'outils avec durabilité et enchantements
         this.toolDurability = {
-            pickaxe: 100,
-            shovel: 80,
-            axe: 90,
-            sword: 70,
-            knife: 60,
-            bow: 50,
-            fishing_rod: 40
+            tool_pickaxe: 100,
+            tool_shovel: 80,
+            tool_axe: 90,
+            tool_sword: 70,
+            tool_knife: 60,
+            tool_bow: 50,
+            tool_fishing_rod: 40
         };
         
         this.toolEnchantments = {
-            pickaxe: ['efficiency', 'unbreaking'],
-            shovel: ['efficiency'],
-            axe: ['efficiency', 'fire_aspect'],
-            sword: ['sharpness', 'fire_aspect'],
-            knife: ['sharpness'],
-            bow: ['power', 'infinity'],
-            fishing_rod: ['luck_of_the_sea']
+            tool_pickaxe: ['efficiency', 'unbreaking'],
+            tool_shovel: ['efficiency'],
+            tool_axe: ['efficiency', 'fire_aspect'],
+            tool_sword: ['sharpness', 'fire_aspect'],
+            tool_knife: ['sharpness'],
+            tool_bow: ['power', 'infinity'],
+            tool_fishing_rod: ['luck_of_the_sea']
         };
         
         this.durability = {
-            pickaxe: 100,
-            shovel: 80,
-            axe: 90,
-            sword: 70,
-            knife: 60,
-            bow: 50,
-            fishing_rod: 40
+            tool_pickaxe: 100,
+            tool_shovel: 80,
+            tool_axe: 90,
+            tool_sword: 70,
+            tool_knife: 60,
+            tool_bow: 50,
+            tool_fishing_rod: 40
         };
         
         this.experience = {
@@ -431,13 +431,13 @@ export class Player {
     getRepairMaterial(toolName) {
         // Matériaux nécessaires pour réparer chaque outil
         const repairMaterials = {
-            pickaxe: TILE.IRON,
-            shovel: TILE.IRON,
-            axe: TILE.IRON,
-            sword: TILE.IRON,
-            knife: TILE.IRON,
-            bow: TILE.WOOD,
-            fishing_rod: TILE.WOOD
+            tool_pickaxe: TILE.IRON,
+            tool_shovel: TILE.IRON,
+            tool_axe: TILE.IRON,
+            tool_sword: TILE.IRON,
+            tool_knife: TILE.IRON,
+            tool_bow: TILE.WOOD,
+            tool_fishing_rod: TILE.WOOD
         };
         return repairMaterials[toolName] || TILE.WOOD;
     }
@@ -636,7 +636,7 @@ export class Player {
 
         const toolName = this.tools[this.selectedToolIndex];
         if (toolName) {
-            const toolAsset = assets[`tool_${toolName}`];
+            const toolAsset = assets[toolName];
             if (toolAsset) {
                 const toolSize = this.w * 0.45; // Shrink tool relative to player size
                 const handOffsetX = this.dir === 1 ? this.w * 0.7 : this.w * 0.3;

--- a/questSystem.js
+++ b/questSystem.js
@@ -78,7 +78,7 @@ export class QuestSystem {
                 { id: 'mine_blocks', description: 'Miner des blocs', target: 10 },
                 { id: 'collect_wood', description: 'Collecter du bois', target: 5 }
             ],
-            { xp: 50, items: [{ name: 'pickaxe', quantity: 1 }] }
+            { xp: 50, items: [{ name: 'tool_pickaxe', quantity: 1 }] }
         ));
 
         this.addQuest(new Quest(
@@ -100,7 +100,7 @@ export class QuestSystem {
             [
                 { id: 'kill_enemies', description: 'Éliminer des ennemis', target: 20 }
             ],
-            { xp: 150, items: [{ name: 'sword', quantity: 1 }] }
+            { xp: 150, items: [{ name: 'tool_sword', quantity: 1 }] }
         ));
 
         this.addQuest(new Quest(


### PR DESCRIPTION
## Summary
- Uniformisation des noms d’outils avec le préfixe `tool_` dans tout le code
- Mise à jour des systèmes (inventaire, quêtes, combat, minage, interface) pour utiliser ces nouveaux identifiants
- Rendu des icônes et affichage des noms adaptés aux fichiers d’assets `tool_*`

## Testing
- `npm test` *(échoue : no test specified)*
- `node --check engine.js inventorySystem.js combatSystem.js miningEngine.js questSystem.js generateurQuete.js player.js itemIcons.js game.js`

------
https://chatgpt.com/codex/tasks/task_e_68905b3adab0832b99f2808892a827c2