### PR TITLE
Centralize mining call and integrate mining stats

### DIFF
--- a/game.js
+++ b/game.js
@@ -5,7 +5,7 @@ import { Player } from './player.js';
 import { TILE, generateLevel, ensureWorldColumns } from './world.js';
 import { PNJ } from './PNJ.js';
 import { generatePNJ } from './generateurPNJ.js';
-import { updateMining, updateGravity } from './miningEngine.js';
+import { updateGravity } from './miningEngine.js';
 import { ParticleSystem } from './fx.js';
 import { WorldAnimator } from './worldAnimator.js';
 import { TimeSystem } from './timeSystem.js';
@@ -495,9 +495,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             });
 
-            // Passe également les touches clavier pour permettre le minage via la touche d'action
-            updateMining(game, mappedKeys, mouse, delta);
-            
             // Système de gravité pour les blocs
             updateGravity(game);
             

--- a/index.html
+++ b/index.html
@@ -1104,7 +1104,6 @@
         import { Enemy } from './enemy.js';
         import { PNJ } from './PNJ.js';
         import { generatePNJ } from './generateurPNJ.js';
-        import { updateMining } from './miningEngine.js';
         import { ParticleSystem } from './fx.js';
         // import { WorldAnimator } from './worldAnimator.js'; // Désactivé pour l'instant
         import { TimeSystem } from './timeSystem.js';
@@ -2435,9 +2434,6 @@
                         }
                     });
 
-                    // Mettre à jour le système de minage
-                    updateMining(game, keys, mouse, delta);
-                    
                     // Mettre à jour les systèmes
                     if (game.particleSystem) game.particleSystem.update();
                     if (game.combatSystem) game.combatSystem.updateDamageNumbers();

--- a/miningEngine.js
+++ b/miningEngine.js
@@ -197,7 +197,10 @@ export function updateMining(game, keys, mouse, delta) {
         }
     }
     
-    const timeToBreak = breakTime / efficiency;
+    // Appliquer les bonus de statistiques et de saison
+    const miningStat = player.stats?.miningSpeed ? player.stats.miningSpeed / 10 : 1;
+    const seasonBonus = game.timeSystem?.getSeasonalBonus ? (game.timeSystem.getSeasonalBonus().mining || 1) : 1;
+    const timeToBreak = breakTime / (efficiency * miningStat * seasonBonus);
     player.miningProgress += delta / timeToBreak;
     game.miningEffect = { x: target.x, y: target.y, progress: player.miningProgress };
 


### PR DESCRIPTION
## Summary
- Remove duplicate mining updates from game and HTML loops to rely on Player.update
- Factor player stats and seasonal bonuses into mining speed

## Testing
- `npm test` (fails: Error: no test specified)
- `node test-mining.js` (MODULE_TYPELESS_PACKAGE_JSON warning)


------
https://chatgpt.com/codex/tasks/task_e_689066cfd08c832b9e5e6a3da9d48364