### PR TITLE
Expand inventory capacity to 32 slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -706,9 +706,9 @@
         </div>
 
         <div id="inventoryMenu" class="overlay">
-            <div class="menu-box" style="max-width: 300px;">
+            <div class="menu-box" style="max-width: 450px;">
                 <h2>INVENTAIRE</h2>
-                <div id="inventoryGrid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; margin: 20px 0;">
+                <div id="inventoryGrid" style="display: grid; grid-template-columns: repeat(8, 1fr); gap: 5px; margin: 20px 0;">
                     <!-- Slots d'inventaire générés dynamiquement -->
                 </div>
                 <div id="chestArea" style="display: none; margin-top: 20px;">
@@ -1636,7 +1636,7 @@
                 particleSystem: new ParticleSystem(),
                 logger: new Logger(),
                 questSystem: new QuestSystem(),
-                inventory: new Inventory(16),
+                inventory: new Inventory(32),
                 combatSystem: new CombatSystem(),
                 biomeSystem: new BiomeSystem(),
                 weatherSystem: new WeatherSystem(config),

--- a/inventorySystem.js
+++ b/inventorySystem.js
@@ -44,9 +44,10 @@ export class InventoryItem {
 }
 
 export class Inventory {
-    constructor(size = 16) {
-        this.size = size;
-        this.slots = new Array(size).fill(null);
+    constructor(size = 32) {
+        // Ensure a minimum inventory size of 32 slots
+        this.size = Math.max(size, 32);
+        this.slots = new Array(this.size).fill(null);
     }
 
     addItem(itemName, quantity = 1, metadata = {}) {


### PR DESCRIPTION
## Summary
- Expand inventory system to guarantee a minimum of 32 slots
- Broaden inventory menu grid to 8 columns for 32 item slots

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68906b6b890c832bb320ed1b07851a09