### PR TITLE
Fix seed parsing for random world generation

### DIFF
--- a/seededRandom.js
+++ b/seededRandom.js
@@ -9,8 +9,19 @@ export const SeededRandom = {
 
     // Réinitialise la graine. Appelé au début de la génération du monde.
     setSeed(newSeed) {
-        this.seed = newSeed;
-        this.originalSeed = newSeed;
+        let seedValue = newSeed;
+        if (typeof seedValue === 'string') {
+            if (/^[0-9]+$/.test(seedValue)) {
+                seedValue = Number(seedValue);
+            } else {
+                seedValue = parseInt(seedValue, 16);
+            }
+        }
+        if (!Number.isFinite(seedValue)) {
+            seedValue = Date.now();
+        }
+        this.seed = seedValue;
+        this.originalSeed = seedValue;
     },
 
     // Génère le prochain nombre pseudo-aléatoire dans la séquence.


### PR DESCRIPTION
## Summary
- sanitize seeds passed to the pseudo-random generator
- fall back to current time when seed cannot be parsed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68906bab3154832ba99ae81f4a6772a8