### PR TITLE
feat: add skill point menu

### DIFF
--- a/combatSystem.js
+++ b/combatSystem.js
@@ -14,6 +14,7 @@ export class PlayerStats {
         this.speed = 10;
         this.mining = 10;
         this.luck = 5;
+        this.skillPoints = 0;
         
         // Effets temporaires
         this.effects = new Map();
@@ -53,6 +54,7 @@ export class PlayerStats {
             this.speed += 1;
             this.mining += 1;
             this.luck += 1;
+            this.skillPoints += 1;
         }
         
         if (levelsGained > 0) {
@@ -210,13 +212,37 @@ export class PlayerStats {
             distanceWalkedTotal: this.distanceWalkedTotal,
             itemsCraftedTotal: this.itemsCraftedTotal,
             deathCount: this.deathCount,
-            playTime: this.playTime
+            playTime: this.playTime,
+            skillPoints: this.skillPoints
         };
     }
 
     deserialize(data) {
         Object.assign(this, data);
         this.updateDerivedStats();
+    }
+
+    allocatePoint(stat) {
+        if (this.skillPoints <= 0) return false;
+        const increments = {
+            strength: 1,
+            defense: 1,
+            speed: 1,
+            mining: 1,
+            luck: 1,
+            maxHealth: 5
+        };
+        const inc = increments[stat];
+        if (!inc) return false;
+        if (stat === 'maxHealth') {
+            this.maxHealth += inc;
+            this.health = this.maxHealth;
+        } else {
+            this[stat] += inc;
+        }
+        this.skillPoints -= 1;
+        this.updateDerivedStats();
+        return true;
     }
 }
 
@@ -486,7 +512,8 @@ export function updatePlayerStatsUI(stats) {
         playerStrength: document.getElementById('playerStrength'),
         playerSpeed: document.getElementById('playerSpeed'),
         healthFill: document.getElementById('healthFill'),
-        healthText: document.getElementById('healthText')
+        healthText: document.getElementById('healthText'),
+        playerSkillPoints: document.getElementById('skillPoints')
     };
 
     if (elements.playerLevel) elements.playerLevel.textContent = stats.level;
@@ -498,6 +525,7 @@ export function updatePlayerStatsUI(stats) {
     if (elements.playerHealth) elements.playerHealth.textContent = `${stats.health}/${stats.maxHealth}`;
     if (elements.playerStrength) elements.playerStrength.textContent = stats.strength;
     if (elements.playerSpeed) elements.playerSpeed.textContent = stats.speed;
+    if (elements.playerSkillPoints) elements.playerSkillPoints.textContent = stats.skillPoints;
     
     if (elements.healthFill) {
         const healthPercent = (stats.health / stats.maxHealth) * 100;

--- a/game.js
+++ b/game.js
@@ -120,6 +120,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const optionsMenu = document.getElementById('optionsMenu');
     const gameOverScreen = document.getElementById('gameOverScreen');
+    const characterMenu = document.getElementById('characterMenu');
     const renderDistanceSlider = document.getElementById('renderDistanceSlider');
     const zoomSlider = document.getElementById('zoomSlider');
     const particlesCheckbox = document.getElementById('particlesCheckbox');
@@ -678,8 +679,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         },
 
-        isPaused: () => optionsMenu.classList.contains('active') || gameOverScreen?.classList.contains('active'),
-        toggleMenu: (menu) => { if (menu === 'options') optionsMenu.classList.toggle('active'); },
+        isPaused: () => optionsMenu.classList.contains('active') || characterMenu?.classList.contains('active') || gameOverScreen?.classList.contains('active'),
+        toggleMenu: (menu) => {
+            if (menu === 'options') optionsMenu.classList.toggle('active');
+            if (menu === 'character') characterMenu?.classList.toggle('active');
+        },
         selectTool: (index) => {
             if (game.player && index >= 0 && index < game.player.tools.length) {
                 game.player.selectedToolIndex = index;

--- a/index.html
+++ b/index.html
@@ -735,16 +735,23 @@
                         </div>
                     </div>
                     <div class="stat-line">
+                        <img src="assets/bonus.png" alt="Points" class="stat-icon">
+                        <span>Points: <span id="skillPoints">0</span></span>
+                    </div>
+                    <div class="stat-line">
                         <img src="assets/heart.png" alt="Santé" class="stat-icon">
                         <span>Santé: <span id="playerHealth">100/100</span></span>
+                        <button class="stat-up" data-stat="maxHealth">+</button>
                     </div>
                     <div class="stat-line">
                         <img src="assets/tool_sword.png" alt="Force" class="stat-icon">
                         <span>Force: <span id="playerStrength">10</span></span>
+                        <button class="stat-up" data-stat="strength">+</button>
                     </div>
                     <div class="stat-line">
                         <img src="assets/player_run1.png" alt="Vitesse" class="stat-icon">
                         <span>Vitesse: <span id="playerSpeed">10</span></span>
+                        <button class="stat-up" data-stat="speed">+</button>
                     </div>
                 </div>
                 <button data-action="close-menu">FERMER</button>
@@ -995,6 +1002,17 @@
                 const target = e.target;
                 const action = target.dataset.action;
 
+                if (target.classList.contains('stat-up') && window.game && window.game.player && window.game.player.stats) {
+                    const stat = target.dataset.stat;
+                    if (window.game.player.stats.allocatePoint(stat)) {
+                        document.getElementById('skillPoints').textContent = window.game.player.stats.skillPoints;
+                        document.getElementById('playerStrength').textContent = window.game.player.stats.strength;
+                        document.getElementById('playerSpeed').textContent = window.game.player.stats.speed;
+                        document.getElementById('playerHealth').textContent = `${window.game.player.stats.health}/${window.game.player.stats.maxHealth}`;
+                    }
+                    return;
+                }
+
                 if (action) {
                     switch(action) {
                         case 'close-menu': target.closest('.overlay').classList.remove('active'); break;
@@ -1034,7 +1052,7 @@
                     } else {
                         openMenu(ui.menus.inventory);
                     }
-                } else if (e.key === 'c' || e.key === 'C') {
+                } else if (e.key === 'p' || e.key === 'P') {
                     e.preventDefault();
                     const isCharacterOpen = ui.menus.character.classList.contains('active');
                     if (isCharacterOpen) {

--- a/style.css
+++ b/style.css
@@ -31,3 +31,10 @@ body.game-page {
     align-items: center;
     justify-content: center;
 }
+
+.stat-up {
+    margin-left: 8px;
+    padding: 0 6px;
+    font-weight: bold;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Reintroduce character menu with skill point upgrades accessible via `P`
- Track and spend skill points to boost health, strength, or speed
- Pause game when character menu is open

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68906b913b20832baf4702fafb71fb9c