### PR TITLE
Fix mining gravity tests and export checkBlockSupport

### DIFF
--- a/miningEngine.js
+++ b/miningEngine.js
@@ -359,7 +359,8 @@ const GRAVITY_BLOCKS = [
     TILE.SAND, TILE.GRAVEL, TILE.SOUL_SAND
 ];
 
-function checkBlockSupport(game, x, y) {
+// Exported for tests and external gravity checks
+export function checkBlockSupport(game, x, y) {
     // Vérifier si un bloc a besoin de support
     const block = game.tileMap[y]?.[x];
     if (!block) return;

--- a/test-mining-fix.js
+++ b/test-mining-fix.js
@@ -28,7 +28,7 @@ export function testGravity(game) {
         config: testConfig,
         tileMap: testMap,
         collectibles: [],
-        gravityTimer: 0
+        gravityTimer: 5 // Run gravity check immediately
     };
     
     // Vérifier l'état initial
@@ -88,11 +88,11 @@ export function testCheckBlockSupport() {
         tileSize: 16
     };
     
-    // Créer une carte de test avec des blocs de sable au-dessus de l'air
+    // Créer une carte de test avec des blocs de sable sans support en dessous
     const testMap = [
         [TILE.AIR, TILE.AIR, TILE.AIR, TILE.AIR, TILE.AIR],
         [TILE.SAND, TILE.AIR, TILE.AIR, TILE.SAND, TILE.AIR],
-        [TILE.STONE, TILE.STONE, TILE.STONE, TILE.STONE, TILE.STONE]
+        [TILE.AIR, TILE.AIR, TILE.AIR, TILE.AIR, TILE.AIR]
     ];
     
     // Créer un objet game de test


### PR DESCRIPTION
## Summary
- export `checkBlockSupport` from mining engine so it can be imported by tests and other modules
- fix mining gravity tests: trigger gravity immediately and use unsupported sand blocks for `checkBlockSupport`

## Testing
- `node -e "import('./test-mining-fix.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68906b9cec54832bb10d0a4d3a997d73