### PR TITLE
feat: make HUD panels draggable modules

### DIFF
--- a/gameIntegration.js
+++ b/gameIntegration.js
@@ -592,22 +592,25 @@ function addComplexWorldUI(game, worldIntegration) {
     // Panneau d'informations du monde complexe
     const worldInfoPanel = document.createElement('div');
     worldInfoPanel.id = 'worldInfoPanel';
-    worldInfoPanel.style.cssText = `
-        position: absolute;
-        top: 200px;
-        right: 20px;
-        width: 200px;
-        background: rgba(0,0,0,0.8);
-        border: 2px solid #666;
-        border-radius: 8px;
-        padding: 10px;
-        color: white;
-        font-size: 12px;
-        font-family: 'VT323', monospace;
+    worldInfoPanel.classList.add('draggable');
+    worldInfoPanel.innerHTML = `
+        <div class="panel-header">
+            <div class="panel-title">MONDE COMPLEXE</div>
+            <div class="panel-controls">
+                <div class="panel-btn minimize-btn">−</div>
+            </div>
+        </div>
+        <div class="panel-content"></div>
+        <div class="resize-handle"></div>
     `;
-    
+
     hudElement.appendChild(worldInfoPanel);
-    
+
+    // Activer les fonctionnalités de module
+    window.makeDraggable?.(worldInfoPanel);
+    window.makeResizable?.(worldInfoPanel);
+    window.setupMinimize?.(worldInfoPanel);
+
     // Mettre à jour le panneau périodiquement
     setInterval(() => {
         updateWorldInfoPanel(game, worldIntegration, worldInfoPanel);
@@ -616,14 +619,15 @@ function addComplexWorldUI(game, worldIntegration) {
 
 function updateWorldInfoPanel(game, worldIntegration, panel) {
     if (!game.player || !game.biomeSystem) return;
-    
+
+    const content = panel.querySelector('.panel-content') || panel;
+
     const currentBiome = game.biomeSystem.getBiomeAt(game, game.player.x, game.player.y);
     const biomeData = game.biomeSystem.getBiomeData(currentBiome);
     const stats = worldIntegration.getWorldStats();
     const progress = game.explorationSystem?.getExplorationProgress();
-    
-    panel.innerHTML = `
-        <h3>🌍 Monde Complexe</h3>
+
+    content.innerHTML = `
         <div><strong>Biome:</strong> ${biomeData?.name || 'Inconnu'}</div>
         <div><strong>Température:</strong> ${biomeData?.temperature || 0}°C</div>
         <div><strong>Humidité:</strong> ${Math.round((biomeData?.humidity || 0) * 100)}%</div>

--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
             overflow: hidden;
         }
 
-        #characterPanel .panel-header {
+        .panel-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -230,18 +230,18 @@
             border-bottom: 1px solid #444;
         }
 
-        #characterPanel .panel-title {
+        .panel-title {
             font-size: 18px;
             color: #FF9800;
             font-weight: bold;
         }
 
-        #characterPanel .panel-controls {
+        .panel-controls {
             display: flex;
             gap: 5px;
         }
 
-        #characterPanel .panel-btn {
+        .panel-btn {
             background: #333;
             border: 1px solid #555;
             color: #fff;
@@ -254,7 +254,7 @@
             justify-content: center;
         }
 
-        #characterPanel .panel-btn:hover {
+        .panel-btn:hover {
             background: #444;
         }
 
@@ -469,6 +469,26 @@
         .info-value {
             color: #FF9800;
             font-weight: bold;
+        }
+
+        /* Panneau d'informations du monde complexe */
+        #worldInfoPanel {
+            position: absolute;
+            top: 200px;
+            right: 20px;
+            width: 200px;
+            background: rgba(0, 0, 0, 0.7);
+            border: 2px solid #444;
+            border-radius: 8px;
+            padding: 15px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+            pointer-events: all;
+            cursor: move;
+        }
+
+        #worldInfoPanel.minimized {
+            height: 40px;
+            overflow: hidden;
         }
 
         /* Menu des catastrophes */
@@ -933,6 +953,10 @@
                 });
             };
 
+            // Rendre les fonctions accessibles globalement pour les modules dynamiques
+            window.makeDraggable = makeDraggable;
+            window.makeResizable = makeResizable;
+            window.setupMinimize = setupMinimize;
 
             // Initialiser les éléments déplaçables après le chargement du DOM
             window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- generalize panel styling and expose drag utilities globally
- add complex world info panel as draggable module

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890729038cc832b809799cfbe716c96