### PR TITLE
feat: make control bindings configurable

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -20,6 +20,17 @@ export class GameEngine {
             run: 'ShiftLeft',
             fly: 'KeyV',
             repair: 'KeyR',
+            inventory: 'KeyI',
+            character: 'KeyP',
+            quests: 'KeyQ',
+            pause: 'Escape',
+            options: 'KeyO',
+            tool1: 'Digit1',
+            tool2: 'Digit2',
+            tool3: 'Digit3',
+            tool4: 'Digit4',
+            tool5: 'Digit5',
+            tool6: 'Digit6',
         };
 
         // Merge provided bindings with defaults in a new config object to
@@ -121,8 +132,8 @@ export class GameEngine {
 
     setupInput() {
         document.addEventListener('keydown', e => {
-            if (this.gameLogic.isPaused && this.gameLogic.isPaused() && !['KeyO', 'Escape', 'F3'].includes(e.code)) return;
             const binds = this.config.keyBindings || {};
+            if (this.gameLogic.isPaused && this.gameLogic.isPaused() && ![binds.pause, 'F3'].includes(e.code)) return;
             if (e.code === binds.left) this.keys.left = true;
             if (e.code === binds.right) this.keys.right = true;
             if (e.code === binds.action) this.keys.action = true;
@@ -135,16 +146,12 @@ export class GameEngine {
             if (e.code === binds.run) this.keys.run = true;
             if (e.code === binds.repair) this.keys.repair = true;
             if (e.code === binds.fly && !e.repeat) this.keys.fly = !this.keys.fly;
-            if (e.code.startsWith('Digit')) {
-                const digit = parseInt(e.code.slice(5));
-                if (digit >= 1 && digit <= 6 && this.gameLogic.selectTool) {
-                    this.gameLogic.selectTool(digit - 1);
+            for (let i = 1; i <= 6; i++) {
+                if (e.code === binds[`tool${i}`] && this.gameLogic.selectTool) {
+                    this.gameLogic.selectTool(i - 1);
                 }
             }
-            if (e.code === 'KeyO' || e.code === 'Escape') {
-                e.preventDefault();
-                if (this.gameLogic.toggleMenu) this.gameLogic.toggleMenu('options');
-            }
+            // L'ouverture des menus est gérée côté interface.
         });
         document.addEventListener('keyup', e => {
             const binds = this.config.keyBindings || {};

--- a/game.js
+++ b/game.js
@@ -91,7 +91,18 @@ async function loadOptions() {
                 "action": "KeyE",
                 "run": "ShiftLeft",
                 "fly": "KeyV",
-                "repair": "KeyR"
+                "repair": "KeyR",
+                "inventory": "KeyI",
+                "character": "KeyP",
+                "quests": "KeyQ",
+                "pause": "Escape",
+                "options": "KeyO",
+                "tool1": "Digit1",
+                "tool2": "Digit2",
+                "tool3": "Digit3",
+                "tool4": "Digit4",
+                "tool5": "Digit5",
+                "tool6": "Digit6"
             }
         };
     }

--- a/index.html
+++ b/index.html
@@ -1186,15 +1186,21 @@
 
             document.addEventListener('keydown', (e) => {
                 if (!isGameRunning) return;
-                
-                if (e.key === 'Escape') {
+
+                const binds = window.game?.config.keyBindings || {};
+
+                if (e.code === binds.pause) {
                     const activeSubMenu = document.querySelector('.overlay.active');
-                    if (activeSubMenu) {
-                        closeMenu(activeSubMenu);
+                    if (activeSubMenu && activeSubMenu !== ui.menus.pause) {
+                        if (activeSubMenu === ui.menus.options) {
+                            window.closeOptionsMenu?.();
+                        } else {
+                            closeMenu(activeSubMenu);
+                        }
                     } else {
                         togglePauseMenu();
                     }
-                } else if (e.key === 'i' || e.key === 'I') {
+                } else if (e.code === binds.inventory) {
                     e.preventDefault();
                     const isInventoryOpen = ui.menus.inventory.classList.contains('active');
                     if (isInventoryOpen) {
@@ -1202,7 +1208,7 @@
                     } else {
                         openMenu(ui.menus.inventory);
                     }
-                } else if (e.key === 'p' || e.key === 'P') {
+                } else if (e.code === binds.character) {
                     e.preventDefault();
                     const isCharacterOpen = ui.menus.character.classList.contains('active');
                     if (isCharacterOpen) {
@@ -1210,7 +1216,7 @@
                     } else {
                         openMenu(ui.menus.character);
                     }
-                } else if (e.key === 'q' || e.key === 'Q') {
+                } else if (e.code === binds.quests) {
                     e.preventDefault();
                     const isQuestOpen = ui.menus.quests.classList.contains('active');
                     if (isQuestOpen) {
@@ -1218,29 +1224,18 @@
                     } else {
                         openMenu(ui.menus.quests);
                     }
-                } else if (e.code && e.code.startsWith('Digit')) {
-                    const digit = parseInt(e.code.slice(5));
-                    if (digit >= 1 && digit <= 6) {
-                        // Sélection d'outils avec les chiffres
-                        const toolIndex = digit - 1;
-                        console.log(`Tentative de sélection outil ${toolIndex}`);
-                        if (window.game && window.game.player && toolIndex < window.game.player.tools.length) {
-                            window.game.player.selectedToolIndex = toolIndex;
-                            window.game.updateToolbar();
-                            console.log(`Outil sélectionné: ${window.game.player.tools[toolIndex]}`);
-                        } else {
-                            console.log("Impossible de sélectionner l'outil:", {
-                                hasGame: !!window.game,
-                                hasPlayer: !!(window.game && window.game.player),
-                                toolsLength: window.game?.player?.tools?.length
-                            });
-                        }
+                } else if (e.code === binds.options) {
+                    e.preventDefault();
+                    if (ui.menus.options.classList.contains('active')) {
+                        window.closeOptionsMenu?.();
+                    } else {
+                        window.openOptionsMenu?.();
                     }
-                } else if (e.ctrlKey && e.key === 's' && window.game) {
+                } else if (e.ctrlKey && e.key.toLowerCase() === 's' && window.game) {
                     // Sauvegarde rapide
                     e.preventDefault();
                     window.game.saveSystem.saveGame(window.game);
-                } else if (e.ctrlKey && e.key === 'l' && window.game) {
+                } else if (e.ctrlKey && e.key.toLowerCase() === 'l' && window.game) {
                     // Chargement rapide
                     e.preventDefault();
                     window.game.saveSystem.loadGame(window.game);
@@ -1545,7 +1540,7 @@
                 return await resp.json();
             } catch (e) {
                 console.warn(e);
-                return {"zoom":3,"renderDistance":8,"showParticles":true,"weatherEffects":true,"dynamicLighting":true,"soundVolume":0.8,"mobileMode":false,"keyBindings":{"left":"ArrowLeft","right":"ArrowRight","jump":"Space","down":"ArrowDown","action":"KeyE","run":"ShiftLeft","fly":"KeyV","repair":"KeyR"}};
+                return {"zoom":3,"renderDistance":8,"showParticles":true,"weatherEffects":true,"dynamicLighting":true,"soundVolume":0.8,"mobileMode":false,"keyBindings":{"left":"ArrowLeft","right":"ArrowRight","jump":"Space","down":"ArrowDown","action":"KeyE","run":"ShiftLeft","fly":"KeyV","repair":"KeyR","inventory":"KeyI","character":"KeyP","quests":"KeyQ","pause":"Escape","options":"KeyO","tool1":"Digit1","tool2":"Digit2","tool3":"Digit3","tool4":"Digit4","tool5":"Digit5","tool6":"Digit6"}};
             }
         }
 

--- a/options.json
+++ b/options.json
@@ -15,6 +15,17 @@
     "action": "KeyE",
     "run": "ShiftLeft",
     "fly": "KeyV",
-    "repair": "KeyR"
+    "repair": "KeyR",
+    "inventory": "KeyI",
+    "character": "KeyP",
+    "quests": "KeyQ",
+    "pause": "Escape",
+    "options": "KeyO",
+    "tool1": "Digit1",
+    "tool2": "Digit2",
+    "tool3": "Digit3",
+    "tool4": "Digit4",
+    "tool5": "Digit5",
+    "tool6": "Digit6"
   }
 }


### PR DESCRIPTION
## Summary
- expose all game commands in key bindings and controls menu
- drive menu toggling from configurable key bindings
- add default bindings for tool slots and UI menus

## Testing
- `npm test` *(fails: no test specified)*
- `node --check engine.js`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68907586a668832baa73896883df93b6