### PR TITLE
feat: add story quest line

### DIFF
--- a/LORE.md
+++ b/LORE.md
@@ -1,0 +1,16 @@
+# Contexte de l'univers
+
+Le monde de **Soleria** était autrefois baigné de lumière. Les cristaux qui
+nourrissaient la terre se sont brisés lorsqu'une entité mystérieuse, connue
+sous le nom de *l'Ombre*, s'est éveillée dans les profondeurs. Cette force
+corruptive a englouti villes et forêts, plongeant la civilisation dans le
+chaos.
+
+Quelques survivants ont bâti des refuges éparpillés. Vous incarnez l'un des
+aventuriers chargés de rassembler les fragments de lumière afin de restaurer
+l'équilibre. Chaque quête de l'histoire principale représente une étape de ce
+combat pour la renaissance de Soleria.
+
+Les quêtes secondaires permettent d'aider les communautés locales, de
+renforcer vos talents et de comprendre les secrets du monde. Ensemble, elles
+forment un récit riche destiné à guider le joueur sur plus de **150 quêtes**.

--- a/storyQuests.js
+++ b/storyQuests.js
@@ -1,0 +1,40 @@
+// storyQuests.js - génération de l'histoire principale
+// Ce module fournit 150 quêtes scénarisées pour former un arc narratif complet.
+
+export function getStoryQuests() {
+    const arcs = [
+        { title: "L'Ombre Émergente", description: "Le royaume de Soleria est envahi par une force obscure qui ronge la terre." },
+        { title: "Les Forges du Renouveau", description: "Les survivants se rassemblent et reforgent les outils nécessaires à la reconquête." },
+        { title: "La Marche des Héros", description: "Les aventuriers se dressent pour repousser l'obscurité." },
+        { title: "Le Voile des Anciens", description: "De vieux secrets refont surface, révélant la véritable origine de l'Ombre." },
+        { title: "L'Aube Retrouvée", description: "La lumière revient peu à peu sur le monde, annonçant un nouvel espoir." }
+    ];
+
+    const quests = [];
+    const total = 150; // Nombre total de quêtes principales
+
+    for (let i = 1; i <= total; i++) {
+        const arc = arcs[Math.floor((i - 1) / 30)]; // 5 arcs de 30 quêtes chacun
+        const step = ((i - 1) % 30) + 1;
+        quests.push({
+            id: `story_${i}`,
+            title: `Chapitre ${i}: ${arc.title}`,
+            description: `${arc.description} (Étape ${step}/30)`,
+            objectives: [
+                {
+                    id: `story_${i}_progress`,
+                    description: `Progresser dans l'aventure (${step}/30)` ,
+                    target: 1
+                }
+            ],
+            rewards: { xp: 100 + i * 5 },
+            prerequisites: i === 1 ? [] : [`story_${i - 1}`],
+            category: 'main'
+        });
+    }
+
+    return quests;
+}
+
+// Le module peut être étendu ultérieurement pour ajouter des quêtes secondaires
+// ou des variations dynamiques.


### PR DESCRIPTION
## Summary
- add 150-story quest generator and lore file
- categorize quest menu with counts
- expand Quest class with category field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689075cda2b0832b95045a62d6884baa