### PR TITLE
feat: spawn animals during day and monsters at night

### DIFF
--- a/animalSystem.js
+++ b/animalSystem.js
@@ -363,16 +363,23 @@ export class AnimalManager {
         this.spawnTimer = 0;
         this.maxAnimals = 50;
     }
-    
+
     update(game, delta) {
-        this.spawnTimer++;
-        
-        // Spawn de nouveaux animaux
-        if (this.spawnTimer > 300 && this.animals.length < this.maxAnimals) { // Toutes les 5 secondes
-            this.trySpawnAnimal(game);
+        const isNight = game.timeSystem?.getStage() === 'nuit';
+
+        if (!isNight) {
+            this.spawnTimer++;
+
+            // Spawn de nouveaux animaux uniquement le jour
+            if (this.spawnTimer > 300 && this.animals.length < this.maxAnimals) { // Toutes les 5 secondes
+                this.trySpawnAnimal(game);
+                this.spawnTimer = 0;
+            }
+        } else {
+            // Réinitialiser le timer la nuit pour éviter un spawn immédiat au lever du soleil
             this.spawnTimer = 0;
         }
-        
+
         // Mettre à jour les animaux existants
         for (let i = this.animals.length - 1; i >= 0; i--) {
             const animal = this.animals[i];

--- a/enemySpawner.js
+++ b/enemySpawner.js
@@ -14,13 +14,20 @@ export class EnemySpawner {
     }
 
     update(game, delta) {
-        this.spawnTimer += delta;
-        
-        if (this.spawnTimer >= this.spawnInterval) {
+        const isNight = game.timeSystem?.getStage() === 'nuit';
+
+        if (isNight) {
+            this.spawnTimer += delta;
+
+            if (this.spawnTimer >= this.spawnInterval) {
+                this.spawnTimer = 0;
+                this.trySpawnEnemy(game);
+            }
+        } else {
+            // Réinitialiser le timer en journée pour éviter un spawn immédiat à la tombée de la nuit
             this.spawnTimer = 0;
-            this.trySpawnEnemy(game);
         }
-        
+
         // Nettoyer les ennemis morts ou trop éloignés
         this.cleanupEnemies(game);
     }


### PR DESCRIPTION
## Summary
- spawn animals only when time system reports day
- restrict enemy spawner to nighttime

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689076722854832ba76b12631267241c