### PR TITLE
Restore day-night cycle visuals

### DIFF
--- a/game.js
+++ b/game.js
@@ -547,6 +547,28 @@ document.addEventListener('DOMContentLoaded', async () => {
             ctx.fillStyle = gradient;
             ctx.fillRect(0, 0, canvas.width, canvas.height);
 
+            // Dessiner le soleil et la lune en fonction de l'heure
+            const { hour, minute } = game.timeSystem.getTime();
+            const t = (hour + minute / 60) / 24;
+            const sunPos = game.timeSystem.getSunPosition(canvas.width, canvas.height);
+            const moonPos = game.timeSystem.getMoonPosition(canvas.width, canvas.height);
+
+            // Soleil
+            ctx.globalAlpha = Math.max(0, Math.sin(t * Math.PI));
+            ctx.fillStyle = '#FDB813';
+            ctx.beginPath();
+            ctx.arc(sunPos.x, sunPos.y, 30, 0, Math.PI * 2);
+            ctx.fill();
+
+            // Lune
+            ctx.globalAlpha = Math.max(0, Math.sin((t + 0.5) * Math.PI));
+            ctx.fillStyle = '#f0f0f0';
+            ctx.beginPath();
+            ctx.arc(moonPos.x, moonPos.y, 20, 0, Math.PI * 2);
+            ctx.fill();
+
+            ctx.globalAlpha = 1;
+
             ctx.save();
             ctx.scale(zoom, zoom);
             ctx.translate(-game.camera.x + game.cameraShakeOffsetX, -game.camera.y + game.cameraShakeOffsetY);

--- a/index.html
+++ b/index.html
@@ -2700,6 +2700,28 @@
                                 gradient.addColorStop(1, skyGrad[1] || '#98D8E8');
                                 ctx.fillStyle = gradient;
                                 ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+                                // Soleil et lune
+                                const { hour, minute } = game.timeSystem.getTime();
+                                const t = (hour + minute / 60) / 24;
+                                const sunPos = game.timeSystem.getSunPosition(canvas.width, canvas.height);
+                                const moonPos = game.timeSystem.getMoonPosition(canvas.width, canvas.height);
+
+                                // Soleil
+                                ctx.globalAlpha = Math.max(0, Math.sin(t * Math.PI));
+                                ctx.fillStyle = '#FDB813';
+                                ctx.beginPath();
+                                ctx.arc(sunPos.x, sunPos.y, 30, 0, Math.PI * 2);
+                                ctx.fill();
+
+                                // Lune
+                                ctx.globalAlpha = Math.max(0, Math.sin((t + 0.5) * Math.PI));
+                                ctx.fillStyle = '#f0f0f0';
+                                ctx.beginPath();
+                                ctx.arc(moonPos.x, moonPos.y, 20, 0, Math.PI * 2);
+                                ctx.fill();
+
+                                ctx.globalAlpha = 1;
                             } catch (e) {
                                 console.warn("Erreur ciel:", e);
                                 ctx.fillStyle = '#87CEEB';


### PR DESCRIPTION
## Summary
- Draw sun and moon according to in-game time
- Render celestial bodies in main HTML to visualize day-night cycle

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689076881e5c832b9970e65c28cdbed2