### PR TITLE
Fix duplicate environment and catastrophe menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,54 +705,7 @@
             <!-- Informations sur l'outil sélectionné -->
             <div id="toolInfo">Sélectionnez un outil</div>
 
-            <!-- Informations environnementales -->
-            <div id="environmentPanel" class="draggable">
-                <div class="panel-header">
-                    <div class="panel-title">ENVIRONNEMENT</div>
-                    <div class="panel-controls">
-                        <div class="panel-btn minimize-btn">−</div>
-                    </div>
-                </div>
-                <div class="panel-content">
-                    <div class="environment-info">
-                        <i class="fa-solid fa-clock info-icon"></i>
-                        <span>Temps: </span>
-                        <span class="info-value" id="gameTime">06:00</span>
-                    </div>
-                    <div class="environment-info">
-                        <i class="fa-solid fa-calendar-day info-icon"></i>
-                        <span>Date: </span>
-                        <span class="info-value" id="gameDate">Jour 1</span>
-                    </div>
-                    <div class="environment-info">
-                        <i id="weatherIcon" class="fa-solid fa-sun info-icon"></i>
-                        <span>Météo: </span>
-                        <span class="info-value" id="gameWeather">Clair</span>
-                    </div>
-                    <div class="environment-info">
-                        <i class="fa-solid fa-mountain info-icon"></i>
-                        <span>Biome: </span>
-                        <span class="info-value" id="currentBiome">Surface</span>
-                    </div>
-                </div>
-                <div class="resize-handle"></div>
-            </div>
-
-            <!-- Menu des catastrophes -->
-            <div id="disasterMenu" class="draggable">
-                <div class="panel-header">
-                    <div class="panel-title">CATASTROPHES</div>
-                    <div class="panel-controls">
-                        <div class="panel-btn minimize-btn">−</div>
-                    </div>
-                </div>
-                <div class="panel-content">
-                    <p><span class="key-hint">F1</span> : Orage</p>
-                    <p><span class="key-hint">F2</span> : Tremblement de terre</p>
-                    <p><span class="key-hint">F3</span> : Pluie de météores</p>
-                </div>
-                <div class="resize-handle"></div>
-            </div>
+            <!-- Les panneaux Environnement et Catastrophes sont désormais générés dynamiquement -->
 
             <!-- Raccourcis de menus -->
             <div id="menuShortcuts" class="draggable">


### PR DESCRIPTION
## Summary
- remove hard-coded Environment and Catastrophe panels from the HUD
- rely on dynamic generation for these panels during game start

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689079d110f8832bb517dce9ddaddf08