### PR TITLE
Fix quest menu key binding for Q key

### DIFF
--- a/game.js
+++ b/game.js
@@ -201,7 +201,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     syncOptionUI();
 
     const game = {
-        config: config,
+        config: engine.config,
         assets: {},
         tileMap: [],
         player: null,
@@ -214,7 +214,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         logger: new Logger(),
         lastTime: 0,
         canvas: canvas,
-        settings: config,
+        settings: engine.config,
         cameraShakeTimer: 0,
         cameraShakeStrength: 0,
         cameraShakeOffsetX: 0,


### PR DESCRIPTION
## Summary
- Ensure game inherits engine default key bindings so the quest menu reacts to the Q key

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689079da9610832b9e22bd95dd951045