### PR TITLE
Fix toolbar tool icon asset lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1975,7 +1975,10 @@
                                 });
                             }
 
-                            const toolAssetName = `tool_${toolName}`;
+                            // Les noms d'outils dans player.tools incluent déjà le préfixe "tool_".
+                            // Éviter d'ajouter un préfixe supplémentaire sinon la recherche d'asset échoue
+                            // (ex. "tool_pickaxe" deviendrait "tool_tool_pickaxe").
+                            const toolAssetName = toolName.startsWith('tool_') ? toolName : `tool_${toolName}`;
                             const toolTexture = this.assets && this.assets[toolAssetName];
                             if (toolTexture) {
                                 const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- Avoid double `tool_` prefix when resolving tool icons so assets display correctly in the toolbar

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node test-player-assets.js`
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_68907a02c638832bb31e82593efda245