### PR TITLE
Add dynamic character panel for player stats

### DIFF
--- a/game.js
+++ b/game.js
@@ -649,6 +649,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             const playerHungerText = document.getElementById('playerHungerText');
             const playerStrength = document.getElementById('playerStrength');
             const playerSpeed = document.getElementById('playerSpeed');
+            const chestsOpened = document.getElementById('chestsOpened');
+            const animalsObserved = document.getElementById('animalsObserved');
+            const survivalItemsFound = document.getElementById('survivalItemsFound');
 
             if (playerLevel) playerLevel.textContent = game.player.stats ? game.player.stats.level : '1';
             if (playerXP) playerXP.textContent = game.player.stats ? `${game.player.stats.xp}/${game.player.stats.xpToNextLevel || 100}` : '0/100';
@@ -680,6 +683,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             
             if (playerStrength) playerStrength.textContent = game.player.stats ? game.player.stats.strength : '10';
             if (playerSpeed) playerSpeed.textContent = game.player.stats ? game.player.stats.speed : '10';
+            if (chestsOpened) chestsOpened.textContent = game.statistics ? game.statistics.chestsOpened : '0';
+            if (animalsObserved) animalsObserved.textContent = game.statistics ? game.statistics.animalsObserved : '0';
+            if (survivalItemsFound) survivalItemsFound.textContent = game.statistics ? game.statistics.survivalItemsFound : '0';
 
             // Mettre à jour les informations environnementales
             if (game.timeSystem) {

--- a/game.js
+++ b/game.js
@@ -683,9 +683,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             
             if (playerStrength) playerStrength.textContent = game.player.stats ? game.player.stats.strength : '10';
             if (playerSpeed) playerSpeed.textContent = game.player.stats ? game.player.stats.speed : '10';
-            if (chestsOpened) chestsOpened.textContent = game.statistics ? game.statistics.chestsOpened : '0';
-            if (animalsObserved) animalsObserved.textContent = game.statistics ? game.statistics.animalsObserved : '0';
-            if (survivalItemsFound) survivalItemsFound.textContent = game.statistics ? game.statistics.survivalItemsFound : '0';
+            if (chestsOpened) chestsOpened.textContent = game.statistics?.chestsOpened ?? '0';
+            if (animalsObserved) animalsObserved.textContent = game.statistics?.animalsObserved ?? '0';
+            if (survivalItemsFound) survivalItemsFound.textContent = game.statistics?.survivalItemsFound ?? '0';
 
             // Mettre à jour les informations environnementales
             if (game.timeSystem) {

--- a/index.html
+++ b/index.html
@@ -650,54 +650,7 @@
     <div id="gameWrapper">
         <canvas id="gameCanvas" tabindex="0"></canvas>
         <div id="hud">
-            <!-- Panneau du personnage -->
-            <div id="characterPanel" class="draggable">
-                <div class="panel-header">
-                    <div class="panel-title">PERSONNAGE</div>
-                    <div class="panel-controls">
-                        <div class="panel-btn minimize-btn">−</div>
-                    </div>
-                </div>
-                <div class="panel-content">
-                    <div class="character-stat">
-                        <span class="stat-label">Niveau:</span>
-                        <span class="stat-value" id="playerLevel">1</span>
-                    </div>
-                    <div class="character-stat">
-                        <span class="stat-label">XP:</span>
-                        <span class="stat-value" id="playerXP">0/100</span>
-                    </div>
-                    <div class="bar-container">
-                        <div class="bar-fill xp-fill" id="playerXPFill" style="width: 0%"></div>
-                        <span class="bar-text" id="playerXPText">0/100</span>
-                    </div>
-                    <div class="character-stat">
-                        <span class="stat-label">Santé:</span>
-                        <span class="stat-value" id="playerHealth">100/100</span>
-                    </div>
-                    <div class="bar-container">
-                        <div class="bar-fill health-fill" id="playerHealthFill" style="width: 100%"></div>
-                        <span class="bar-text" id="playerHealthText">100/100</span>
-                    </div>
-                    <div class="character-stat">
-                        <span class="stat-label">Faim:</span>
-                        <span class="stat-value" id="playerHunger">100/100</span>
-                    </div>
-                    <div class="bar-container">
-                        <div class="bar-fill hunger-fill" id="playerHungerFill" style="width: 100%"></div>
-                        <span class="bar-text" id="playerHungerText">100/100</span>
-                    </div>
-                    <div class="character-stat">
-                        <span class="stat-label">Force:</span>
-                        <span class="stat-value" id="playerStrength">10</span>
-                    </div>
-                    <div class="character-stat">
-                        <span class="stat-label">Vitesse:</span>
-                        <span class="stat-value" id="playerSpeed">10</span>
-                    </div>
-                </div>
-                <div class="resize-handle"></div>
-            </div>
+            <!-- Panneau du personnage généré dynamiquement -->
 
             <!-- Barre d'outils -->
             <div id="toolbar"></div>
@@ -1282,7 +1235,7 @@
         import { FoodSystem } from './foodSystem.js';
         import { ComplexWorldSystem } from './worldComplexSystem.js';
         import { integrateComplexWorld } from './gameIntegration.js';
-        import { createEnvironmentPanel, createDisasterMenu } from './uiPanels.js';
+        import { createEnvironmentPanel, createDisasterMenu, createCharacterPanel } from './uiPanels.js';
         
         // Fonction pour générer le loot des coffres
         function generateChestLoot(chestType) {
@@ -1579,6 +1532,7 @@
 
             createEnvironmentPanel(hud);
             createDisasterMenu(hud);
+            createCharacterPanel(hud);
 
             function resizeCanvas() {
                 canvas.width = window.innerWidth;

--- a/uiPanels.js
+++ b/uiPanels.js
@@ -60,3 +60,64 @@ export function createDisasterMenu(hud) {
     window.makeResizable?.(panel);
     window.setupMinimize?.(panel);
 }
+
+export function createCharacterPanel(hud) {
+    if (!hud) return;
+    const content = `
+        <div class="character-content">
+            <div class="character-stat">
+                <span class="stat-label">Niveau:</span>
+                <span class="stat-value" id="playerLevel">1</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">XP:</span>
+                <span class="stat-value" id="playerXP">0/100</span>
+            </div>
+            <div class="bar-container">
+                <div class="bar-fill xp-fill" id="playerXPFill" style="width: 0%"></div>
+                <span class="bar-text" id="playerXPText">0/100</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Santé:</span>
+                <span class="stat-value" id="playerHealth">100/100</span>
+            </div>
+            <div class="bar-container">
+                <div class="bar-fill health-fill" id="playerHealthFill" style="width: 100%"></div>
+                <span class="bar-text" id="playerHealthText">100/100</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Faim:</span>
+                <span class="stat-value" id="playerHunger">100/100</span>
+            </div>
+            <div class="bar-container">
+                <div class="bar-fill hunger-fill" id="playerHungerFill" style="width: 100%"></div>
+                <span class="bar-text" id="playerHungerText">100/100</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Force:</span>
+                <span class="stat-value" id="playerStrength">10</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Vitesse:</span>
+                <span class="stat-value" id="playerSpeed">10</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Coffres:</span>
+                <span class="stat-value" id="chestsOpened">0</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Animaux:</span>
+                <span class="stat-value" id="animalsObserved">0</span>
+            </div>
+            <div class="character-stat">
+                <span class="stat-label">Survie:</span>
+                <span class="stat-value" id="survivalItemsFound">0</span>
+            </div>
+        </div>
+    `;
+    const panel = createPanel('characterPanel', 'PERSONNAGE', content);
+    hud.appendChild(panel);
+    window.makeDraggable?.(panel);
+    window.makeResizable?.(panel);
+    window.setupMinimize?.(panel);
+}


### PR DESCRIPTION
## Summary
- replace static character HUD with draggable, resizable panel
- display chest, animal and survival counters alongside core stats
- update game loop to populate new UI elements

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689082b6c10c832b89e6dcd658878c78