### PR TITLE
fix: handle space key normalization

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -131,7 +131,13 @@ export class GameEngine {
     }
 
     setupInput() {
-        const normalizeKey = k => (k.length === 1 ? k.toLowerCase() : k);
+        // Normalise les noms de touches pour gérer les variations selon les navigateurs.
+        // Certains retournent "Space" ou "Spacebar" pour la barre d'espace, ce qui empêchait
+        // les commandes de saut ou de vol d'être détectées correctement.
+        const normalizeKey = k => {
+            if (k === ' ' || k === 'Spacebar' || k === 'Space') return ' ';
+            return k.length === 1 ? k.toLowerCase() : k;
+        };
         document.addEventListener('keydown', e => {
             const binds = this.config.keyBindings || {};
             const key = normalizeKey(e.key);


### PR DESCRIPTION
## Summary
- fix jump/fly controls by normalizing spacebar key names

## Testing
- `npm test` (fails: Error: no test specified)
- `node test-player.js`


------
https://chatgpt.com/codex/tasks/task_e_68908d2be134832b9d0da495a8880bbd