### PR TITLE
Fix player flying toggle and animation input state

### DIFF
--- a/player.js
+++ b/player.js
@@ -88,6 +88,9 @@ export class Player {
     update(keys, game, delta) {
         if (!game || !game.tileMap) return;
 
+        // Conserver l'état des touches pour l'animation
+        this.keys = keys;
+
         const physics = this.config.physics;
 
         // --- Mouvements ---
@@ -113,10 +116,8 @@ export class Player {
     }
 
     handleMovement(keys, physics) {
-        // Gestion du vol
-        if (keys.fly) {
-            this.isFlying = !this.isFlying;
-        }
+        // Gestion du vol : le vol est activé si la touche correspondante est active
+        this.isFlying = !!keys.fly;
         
         // Gestion de l'accroupissement et position allongée
         if (keys.down && this.isGrounded) {


### PR DESCRIPTION
## Summary
- Keep key state on Player to drive animations
- Use fly key state directly instead of toggling each frame

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689202e03de8832bb0fbb05e15f43930