### PR TITLE
Fix mining state reset and block placement inventory

### DIFF
--- a/miningEngine.js
+++ b/miningEngine.js
@@ -197,7 +197,10 @@ export function updateMining(game, keys, mouse, delta) {
     }
     
     if (!isMining || !player.miningTarget) {
-        if (player) player.miningProgress = 0;
+        if (player) {
+            player.miningProgress = 0;
+            player.miningTarget = null;
+        }
         game.miningEffect = null;
         return;
     }

--- a/player.js
+++ b/player.js
@@ -318,12 +318,13 @@ export class Player {
         const tileX = Math.floor(mouseX / tileSize);
         const tileY = Math.floor(mouseY / tileSize);
 
-        // Vérifier si le joueur a le bloc dans son inventaire
+        // Vérifier si le joueur possède le bloc dans son inventaire
         const blockToPlace = TILE.DIRT; // Exemple: toujours placer de la terre
-        if (this.inventory[blockToPlace] > 0) {
+        const itemKey = this.getItemFromBlock(blockToPlace);
+        if ((this.inventory[itemKey] || 0) > 0) {
             if (game.tileMap[tileY]?.[tileX] === TILE.AIR) {
                 game.tileMap[tileY][tileX] = blockToPlace;
-                this.inventory[blockToPlace]--;
+                this.inventory[itemKey]--;
                 if(game.logger) game.logger.log(`Bloc ${blockToPlace} placé à (${tileX},${tileY})`, 'action');
             }
         }


### PR DESCRIPTION
## Summary
- Reset mining target when mining stops to avoid stuck mining progress
- Fix block placement to check inventory using item names and decrement correctly

## Testing
- `npm test`
- `node -e "require('./miningEngine.js'); console.log('loaded');"`
- `node - <<'NODE'
const {Player} = require('./player.js');
const game = { mouse:{x:0,y:0}, camera:{x:0,y:0}, tileMap:[[0,0],[0,0]], logger:{log:console.log} };
const config = { tileSize:32, zoom:1, player:{width:32,height:48}, physics:{} };
const player = new Player(0,0,config);
player.inventory['dirt'] = 1;
player.handleBuilding(game);
console.log('tileMap:', game.tileMap);
console.log('inventory dirt:', player.inventory['dirt']);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689205168bd4832b8eebfe64dec653f5