### PR TITLE
Fix player hitbox dimensions

### DIFF
--- a/config.json
+++ b/config.json
@@ -73,8 +73,8 @@
     "hitbox": {
       "offsetX": 0,
       "offsetY": 0,
-      "width": 1,
-      "height": 1
+      "width": 48,
+      "height": 72
     },
     "reach": 4,
     "attackRange": 20


### PR DESCRIPTION
## Summary
- set player hitbox to match sprite size to prevent walking through terrain

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68920a711750832b99a18773aaaab636