### PR TITLE
fix: prevent stretched canvas on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,6 +52,7 @@ body.game-page {
     image-rendering: pixelated;
     image-rendering: -moz-crisp-edges;
     image-rendering: crisp-edges;
+    object-fit: contain;
 }
 
 .stat-up {


### PR DESCRIPTION
## Summary
- ensure game canvas keeps its aspect ratio on desktop to avoid stretched interface

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892405e1574832b95da3e9334462e2b